### PR TITLE
fix(): missing comma in Lua config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ require("flutter-tools").setup {
   },
   outline = {
     open_cmd = "30vnew",
-  }
+  },
   lsp = {
     on_attach = my_custom_on_attach,
     capabilities = my_custom_capabilities -- e.g. lsp_status capabilities


### PR DESCRIPTION
While trying to setup the plugin, I got the below error when `neovim` started:

`E5107: Error loading lua [string ":lua"]:15: '}' expected (to close '{' at line 4) near 'lsp'` 

the error was fixed when I added the missing comma in Lua configuration.

PS: sorry to open it as a PR. Please feel free to suggest opening an issue instead. Whichever is best for you.