### PR TITLE
doc: configure dartls according to nvim-lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ or using `packer.nvim`
 use {"akinsho/flutter-tools.nvim", requires = {"neovim/nvim-lspconfig"}}
 ```
 
-Currently this plugin depends on `nvim-lspconfig` for some default setup this might change.
+Currently this plugin depends on `nvim-lspconfig` mainly on the setup of the `dartls`. Therefore, it assumes that `dartls` has already been configured according to the instructions in [`nvim-lspconfig CONFIG.md`](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md) (including the `cmd` parameter to specify the language server executable).
+
 To set it up
 
 ```lua


### PR DESCRIPTION
Thank you @akinsho for this awesome plugin!, can't wait to see you releasing it officially.

During setup, I wrongly had the impression this plugin also configures the `dartls`. But after sometime, I realised I must configure `dartls` according to `nvim-lspconfig` to get the LSP things.

I am tempted to mention that `dartls` should be configured according to the instructions in `nvim-lspconfig`. It could save a lot of time for other people.