### PR TITLE
Automagically try and derive Flutter binary and lsp server paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ require("flutter-tools").setup{} -- use defaults
 
 -- alternatively you can override the default configs
 require("flutter-tools").setup {
-  flutter_path = "<full/path/if/needed>", -- <-- this takes priority over the lookup
-  flutter_lookup_cmd = nil, -- example "which flutter" or "asdf which flutter"
   experimental = { -- map of feature flags
     derive_lsp_paths = false, -- EXPERIMENTAL: Attempt to find the user's flutter SDK
   }
+  flutter_path = "<full/path/if/needed>", -- <-- this takes priority over the lookup
+  flutter_lookup_cmd = nil, -- example "which flutter" or "asdf which flutter"
   flutter_outline = {
     highlight = "NonText",
     enabled = false,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # flutter-tools.nvim
 
-Tools to help create flutter apps in neovim using the native lsp
+Build flutter and dart applications in neovim using the native lsp.
 
 **Status: Alpha**
+
+#### NOTE
+
+I plan to try and keep things _relatively_ stable but ultimately there might still need to be some
+breaking changes while I flesh out some of the functionality.
 
 # Inspiration
 
@@ -38,6 +43,9 @@ require("flutter-tools").setup{} -- use defaults
 require("flutter-tools").setup {
   flutter_path = "<full/path/if/needed>", -- <-- this takes priority over the lookup
   flutter_lookup_cmd = nil, -- example "which flutter" or "asdf which flutter"
+  experimental = { -- map of feature flags
+    derive_lsp_paths = false, -- EXPERIMENTAL: Attempt to find the user's flutter SDK
+  }
   flutter_outline = {
     highlight = "NonText",
     enabled = false,

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -60,10 +60,7 @@ local function setup_autocommands()
 end
 
 function M.setup(user_config)
-  config.set(user_config)
-  if user_config.lsp then
-    lsp.setup(user_config.lsp)
-  end
+  lsp.setup(config.set(user_config))
   setup_commands()
   setup_autocommands()
 end

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -19,8 +19,8 @@ function M.set(user_config)
   -- we setup the defaults here so that dynamic values
   -- can be calculated as close as possible to usage
   local defaults = {
-    dart_lookup_cmd = "which dart",
-    flutter_lookup_cmd = "which flutter",
+    flutter_path = nil,
+    flutter_lookup_cmd = "flutter sdk-path",
     flutter_outline = {
       highlight = "Normal",
       enabled = false

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -16,7 +16,7 @@ end
 
 local defaults = {
   flutter_path = nil,
-  flutter_lookup_cmd = "flutter sdk-path",
+  flutter_lookup_cmd = nil,
   flutter_outline = {
     highlight = "Normal",
     enabled = false
@@ -46,7 +46,18 @@ local defaults = {
   }
 }
 
-local config = setmetatable({}, {__index = defaults})
+local config =
+  setmetatable(
+  {},
+  {
+    __index = function(tbl, key)
+      if key == "flutter_lookup_cmd" and tbl.experimental and tbl.experimental.lsp_derive_paths then
+        return "flutter sdk-path"
+      end
+      return defaults[key]
+    end
+  }
+)
 
 function M.get()
   return config

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -19,8 +19,8 @@ function M.set(user_config)
   -- we setup the defaults here so that dynamic values
   -- can be calculated as close as possible to usage
   local defaults = {
-    flutter_path = nil,
-    flutter_lookup_cmd = nil,
+    dart_lookup_cmd = "which dart",
+    flutter_lookup_cmd = "which flutter",
     flutter_outline = {
       highlight = "Normal",
       enabled = false
@@ -37,7 +37,7 @@ function M.set(user_config)
     }
   }
 
-  config = user_config and vim.deepcopy(user_config) or {}
+  config = user_config or {}
   validate_prefs(config)
   setmetatable(config, {__index = defaults})
 end

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -16,7 +16,7 @@ end
 
 local defaults = {
   flutter_path = nil,
-  flutter_lookup_cmd = nil,
+  flutter_lookup_cmd = utils.is_linux and "flutter sdk-path" or nil,
   flutter_outline = {
     highlight = "Normal",
     enabled = false
@@ -46,18 +46,7 @@ local defaults = {
   }
 }
 
-local config =
-  setmetatable(
-  {},
-  {
-    __index = function(tbl, key)
-      if key == "flutter_lookup_cmd" and tbl.experimental and tbl.experimental.lsp_derive_paths then
-        return "flutter sdk-path"
-      end
-      return defaults[key]
-    end
-  }
-)
+local config = setmetatable({}, {__index = defaults})
 
 function M.get()
   return config

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -9,7 +9,40 @@ local function validate_prefs(prefs)
   }
 end
 
-local config = {}
+local function get_split_cmd(percentage, fallback)
+  return string.format("botright %dvnew", math.max(vim.o.columns * percentage, fallback))
+end
+
+local defaults = {
+  flutter_path = nil,
+  flutter_lookup_cmd = "flutter sdk-path",
+  flutter_outline = {
+    highlight = "Normal",
+    enabled = false
+  },
+  closing_tags = {
+    highlight = "Comment",
+    prefix = "//"
+  },
+  outline = setmetatable(
+    {},
+    {
+      __index = function(_, k)
+        return k == "open_cmd" and get_split_cmd(0.3, 40) or nil
+      end
+    }
+  ),
+  dev_log = setmetatable(
+    {},
+    {
+      __index = function(_, k)
+        return k == "open_cmd" and get_split_cmd(0.4, 50) or nil
+      end
+    }
+  )
+}
+
+local config = setmetatable({}, {__index = defaults})
 
 function M.get()
   return config
@@ -18,28 +51,10 @@ end
 function M.set(user_config)
   -- we setup the defaults here so that dynamic values
   -- can be calculated as close as possible to usage
-  local defaults = {
-    flutter_path = nil,
-    flutter_lookup_cmd = "flutter sdk-path",
-    flutter_outline = {
-      highlight = "Normal",
-      enabled = false
-    },
-    closing_tags = {
-      highlight = "Comment",
-      prefix = "//"
-    },
-    dev_log = {
-      open_cmd = string.format("botright %dvnew", math.max(vim.o.columns * 0.4, 50))
-    },
-    outline = {
-      open_cmd = string.format("botright %dvnew", math.max(vim.o.columns * 0.3, 40))
-    }
-  }
+  user_config = user_config or {}
 
-  config = user_config or {}
+  config = vim.tbl_deep_extend("keep", user_config, config)
   validate_prefs(config)
-  setmetatable(config, {__index = defaults})
 end
 
 return M

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -1,3 +1,4 @@
+local utils = require("flutter-tools/utils")
 local M = {}
 
 --- @param prefs table user preferences
@@ -39,7 +40,10 @@ local defaults = {
         return k == "open_cmd" and get_split_cmd(0.4, 50) or nil
       end
     }
-  )
+  ),
+  experimental = {
+    lsp_derive_paths = false
+  }
 }
 
 local config = setmetatable({}, {__index = defaults})
@@ -49,12 +53,10 @@ function M.get()
 end
 
 function M.set(user_config)
-  -- we setup the defaults here so that dynamic values
-  -- can be calculated as close as possible to usage
   user_config = user_config or {}
-
-  config = vim.tbl_deep_extend("keep", user_config, config)
+  config = utils.merge(config, user_config)
   validate_prefs(config)
+  return config
 end
 
 return M

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -50,15 +50,15 @@ function M.get_flutter()
   if M.flutter_bin_path then
     return M.flutter_bin_path
   end
-  local user_config = config.get()
-  if user_config.flutter_path then
-    M.flutter_bin_path = user_config.flutter_path
-  elseif user_config.flutter_lookup_cmd then
-    M.flutter_sdk_path = utils.remove_newlines(fn.system(user_config.flutter_lookup_cmd))
+  local cfg = config.get()
+  if cfg.flutter_path then
+    M.flutter_bin_path = cfg.flutter_path
+  elseif cfg.flutter_lookup_cmd then
+    M.flutter_sdk_path = utils.remove_newlines(fn.system(cfg.flutter_lookup_cmd))
     M.dart_bin_path = utils.join {M.flutter_sdk_path, "bin", "dart"}
     M.flutter_bin_path = utils.join {M.flutter_sdk_path, "bin", "flutter"}
     if vim.v.shell_error > 0 or vim.v.shell_error == -1 then
-      ui.notify(string.format("Error running %s", user_config.flutter_lookup_cmd))
+      ui.notify(string.format("Error running %s", cfg.flutter_lookup_cmd))
     end
   end
 

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -1,28 +1,68 @@
 local config = require("flutter-tools/config")
+local utils = require("flutter-tools/utils")
+local ui = require("flutter-tools/ui")
 
 local fn = vim.fn
 
-local M = {}
+local M = {
+  dart_bin_name = "dart",
+  dart_bin_path = nil,
+  flutter_bin_path = nil,
+  flutter_sdk_path = nil
+}
+
+local dart_sdk = utils.join {"cache", "dart-sdk", "bin", "dart"}
+
+function M.dart_sdk_root_path(user_bin_path)
+  if user_bin_path then
+    return utils.join {user_bin_path, dart_sdk}
+  elseif utils.executable("flutter") then
+    local _, flutter_sdk = M.get_flutter()
+    if flutter_sdk then
+      -- On Linux installations with snap the dart SDK can be further nested inside a bin directory
+      -- so it's /bin/cache/dart-sdk whereas else where it is /cache/dart-sdk
+      local paths = {flutter_sdk, "cache"}
+      if not utils.is_dir(utils.join(paths)) then
+        table.insert(paths, 2, "bin")
+      end
+      if utils.is_dir(utils.join(paths)) then
+        -- remove the /cache/ directory as it's already part of the SDK path above
+        paths[#paths] = nil
+        return utils.join(vim.tbl_flatten {paths, dart_sdk})
+      end
+    else
+      local flutter_path = fn.resolve(fn.exepath("flutter"))
+      local flutter_bin = fn.fnamemodify(flutter_path, ":h")
+      return utils.join {flutter_bin, dart_sdk}
+    end
+  elseif utils.executable("dart") then
+    return fn.resolve(fn.exepath("dart"))
+  else
+    return ""
+  end
+end
 
 ---Fetch the path to the users flutter installation.
 ---NOTE: this should not be called before the plugin
----setup has occured
+---setup has occurred
 ---@return string
 function M.get_flutter()
-  if M.path then
-    return M.path
+  if M.flutter_bin_path then
+    return M.flutter_bin_path
   end
-  local c = config.get()
-  if c.flutter_path then
-    M.path = c.flutter_path
-  elseif c.flutter_lookup_cmd then
-    -- TODO the experience could be nicer if this
-    -- ends up blocking for too long
-    M.path = fn.system(c.lookup_cmd):gsub("[\n\r]", "")
-  else
-    M.path = fn.resolve(fn.exepath("flutter"))
+  local user_config = config.get()
+  if user_config.flutter_path then
+    M.flutter_bin_path = user_config.flutter_path
+  elseif user_config.flutter_lookup_cmd then
+    M.flutter_sdk_path = utils.remove_newlines(fn.system(user_config.flutter_lookup_cmd))
+    M.dart_bin_path = utils.join {M.flutter_sdk_path, "bin", "dart"}
+    M.flutter_bin_path = utils.join {M.flutter_sdk_path, "bin", "flutter"}
+    if vim.v.shell_error > 0 or vim.v.shell_error == -1 then
+      ui.notify(string.format("Error running %s", user_config.flutter_lookup_cmd))
+    end
   end
-  return M.path
+
+  return M.flutter_bin_path, M.flutter_sdk_path
 end
 
 ---Prefix a command with the flutter executable

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -42,6 +42,12 @@ function M.dart_sdk_root_path(user_bin_path)
   end
 end
 
+local function report_shell_error(msg)
+  if vim.v.shell_error > 0 or vim.v.shell_error == -1 then
+    ui.notify(string.format("Error running %s", msg))
+  end
+end
+
 ---Fetch the path to the users flutter installation.
 ---NOTE: this should not be called before the plugin
 ---setup has occurred
@@ -57,9 +63,10 @@ function M.get_flutter()
     M.flutter_sdk_path = utils.remove_newlines(fn.system(cfg.flutter_lookup_cmd))
     M.dart_bin_path = utils.join {M.flutter_sdk_path, "bin", "dart"}
     M.flutter_bin_path = utils.join {M.flutter_sdk_path, "bin", "flutter"}
-    if vim.v.shell_error > 0 or vim.v.shell_error == -1 then
-      ui.notify(string.format("Error running %s", cfg.flutter_lookup_cmd))
-    end
+    report_shell_error(cfg.flutter_lookup_cmd)
+  else
+    M.dart_bin_path = fn.resolve(fn.exepath("dart"))
+    M.flutter_bin_path = fn.resolve(fn.exepath("flutter"))
   end
 
   return M.flutter_bin_path, M.flutter_sdk_path

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -10,14 +10,11 @@ local M = {
 
 local function analysis_server_snapshot_path(dart_sdk_path)
   local dart_sdk_root_path = fn.fnamemodify(dart_sdk_path, ":h")
-  local snapshot = utils.join {dart_sdk_root_path, "snapshots", "analysis_server.dart.snapshot"}
-  print("snapshot: " .. vim.inspect(snapshot))
-
-  return snapshot
+  return utils.join {dart_sdk_root_path, "snapshots", "analysis_server.dart.snapshot"}
 end
 
-function M.setup(config)
-  config = config or {}
+function M.setup(user_config)
+  local config = (user_config and user_config.lsp) and user_config.lsp or {}
   if M.initialised then
     return utils.echomsg [[DartLS has already been setup!]]
   end
@@ -27,10 +24,7 @@ function M.setup(config)
     return
   end
 
-  local executable = require("flutter-tools/executable")
-  local dart_sdk_path = executable.dart_sdk_root_path()
   local cfg = {
-    cmd = {executable.dart_bin_name, analysis_server_snapshot_path(dart_sdk_path), "--lsp"},
     init_options = {
       closingLabels = true,
       outline = true,
@@ -42,6 +36,11 @@ function M.setup(config)
       ["dart/textDocument/publishFlutterOutline"] = outline.flutter_outline
     }
   }
+  if user_config.experimental.lsp_derive_paths then
+    local executable = require("flutter-tools/executable")
+    local dart_sdk_path = executable.dart_sdk_root_path()
+    cfg.cmd = {executable.dart_bin_name, analysis_server_snapshot_path(dart_sdk_path), "--lsp"}
+  end
 
   config = vim.tbl_deep_extend("force", cfg, config)
   lspconfig.dartls.setup(config)

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -2,9 +2,38 @@ local utils = require "flutter-tools/utils"
 local labels = require "flutter-tools/labels"
 local outline = require "flutter-tools/outline"
 
+local fn = vim.fn
+
 local M = {
   initialised = false
 }
+
+local bin_name = "dart"
+
+local function find_dart_sdk_root_path(user_bin_path)
+  if user_bin_path then
+    return user_bin_path .. "/cache/dart-sdk/bin/dart"
+  elseif fn.executable("flutter") == 1 then
+    local flutter_path = fn.resolve(fn.exepath("flutter"))
+    local flutter_bin = fn.fnamemodify(flutter_path, ":h")
+    return flutter_bin.."/cache/dart-sdk/bin/dart"
+  elseif fn.executable("dart") == 1 then
+    return fn.resolve(fn.exepath("dart"))
+  else
+    return ''
+  end
+end
+
+local function analysis_server_snapshot_path()
+  local dart_sdk_root_path = fn.fnamemodify(find_dart_sdk_root_path(), ":h")
+  local snapshot = dart_sdk_root_path.."/snapshots/analysis_server.dart.snapshot"
+
+  if fn.has("win32") == 1 or fn.has("win64") == 1 then
+    snapshot = snapshot:gsub("/", "\\")
+  end
+
+  return snapshot
+end
 
 function M.setup(config)
   config = config or {}
@@ -17,7 +46,9 @@ function M.setup(config)
     return
   end
 
+  local c = require('flutter-tools.config').get()
   local cfg = {
+    cmd = {bin_name, analysis_server_snapshot_path(c.flutter_path), "--lsp"};
     flags = {allow_incremental_sync = true},
     init_options = {
       closingLabels = true,

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -138,6 +138,8 @@ function M.join(segments)
   return table.concat(segments, M.sep)
 end
 
+local sys_name = vim.loop.os_uname().sysname
+M.is_linux = sys_name == "Linux"
 M.is_windows = fn.has("win32") == 1 or fn.has("win64") == 1
 
 M.sep = fn.has("win32") == 1 or fn.has("win64") == 1 and "\\" or "/"

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -1,4 +1,5 @@
 local M = {}
+local fn = vim.fn
 local api = vim.api
 
 function M.echomsg(msg, hl)
@@ -107,11 +108,41 @@ function M.augroup(name, commands)
   vim.cmd("augroup END")
 end
 
-function M.fold(accumulator, fn, list)
+function M.fold(accumulator, callback, list)
   for _, v in ipairs(list) do
-    accumulator = fn(accumulator, v)
+    accumulator = callback(accumulator, v)
   end
   return accumulator
+end
+
+---Join segments of a path into a full path with
+---the correct separator
+---@param segments string[]
+function M.join(segments)
+  return table.concat(segments, M.sep)
+end
+
+M.is_windows = fn.has("win32") == 1 or fn.has("win64") == 1
+
+M.sep = fn.has("win32") == 1 or fn.has("win64") == 1 and "\\" or "/"
+
+function M.remove_newlines(str)
+  if not str or type(str) ~= "string" then
+    return str
+  end
+  return str:gsub("[\n\r]", "")
+end
+
+function M.format_path(path)
+  return M.is_windows and path:gsub("/", "\\") or path
+end
+
+function M.executable(bin)
+  return fn.executable(bin) > 0
+end
+
+function M.is_dir(path)
+  return fn.isdirectory(path) > 0
 end
 
 return M

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -115,6 +115,22 @@ function M.fold(accumulator, callback, list)
   return accumulator
 end
 
+---Merge two table but maintain metatables
+---Priority is given to the second table
+---@param t1 table
+---@param t2 table
+---@return table
+function M.merge(t1, t2)
+  for k, v in pairs(t2) do
+    if (type(v) == "table") and (type(t1[k] or false) == "table") then
+      M.merge(t1[k], t2[k])
+    else
+      t1[k] = v
+    end
+  end
+  return t1
+end
+
 ---Join segments of a path into a full path with
 ---the correct separator
 ---@param segments string[]


### PR DESCRIPTION
This PR is based on prior art like [`Dart-Code`](https://github.com/Dart-Code/Dart-Code/blob/81b7711c970e3adb5b2933a3e34e49a39b8e7b07/src/extension/sdk/utils.ts) and [`coc-flutter`](https://github.com/iamcco/coc-flutter/pull/91/files). It's miles off those examples level of complexity for now because it won't support things like `asdf` and `fvm` out of the box. Those will come much later. This should be most useful for people using a `snap` build of flutter, but hopefully doesn't break for mac or other linux users.

It relies on `flutter sdk-path` which I'm not sure yet is universal for all versions of flutter.

Currently hidden behind an experimental flag
```lua
require('flutter-tools').setup {
  experimental = { derive_lsp_paths = true }
}
```

#### TODO
- [ ] test on macOS