### PR TITLE
Remove dependency on lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ or using `packer.nvim`
 use "akinsho/flutter-tools.nvim"
 ```
 
+NOTE: flutter tools does not depend on `nvim-lspconfig`. The two can co-exist but please ensure
+you do **NOT** configure `dartls` using `lspconfig`. It will be automatically set up by this
+plugin instead.
+
 To set it up
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -23,17 +23,15 @@ to allow users to easily develop flutter apps using neovim.
 using `vim-plug`
 
 ```vim
-Plug "neovim/nvim-lspconfig"
 Plug "akinsho/flutter-tools.nvim"
 ```
 
 or using `packer.nvim`
 
 ```lua
-use {"akinsho/flutter-tools.nvim", requires = {"neovim/nvim-lspconfig"}}
+use "akinsho/flutter-tools.nvim"
 ```
 
-Currently this plugin depends on `nvim-lspconfig` for some default setup this might change.
 To set it up
 
 ```lua
@@ -65,6 +63,10 @@ require("flutter-tools").setup {
   lsp = {
     on_attach = my_custom_on_attach,
     capabilities = my_custom_capabilities -- e.g. lsp_status capabilities
+    settings = {
+      showTodos = true,
+      completeFunctionCalls = true -- NOTE: this is WIP and doesn't work currently
+    }
   }
 }
 ```

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -48,7 +48,7 @@ end
 function M.setup(user_config)
   local conf = require("flutter-tools.config").set(user_config)
 
-  require("flutter-tools.lsp").setup(conf)
+  require("flutter-tools.lsp").setup()
 
   if conf.debugger.enabled then
     require("flutter-tools.dap").setup(conf)

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -1,5 +1,4 @@
-local utils = require("flutter-tools.utils")
-
+local path = require("flutter-tools.utils.path")
 local M = {}
 
 local fmt = string.format
@@ -27,7 +26,7 @@ M.debug_levels = {
 
 local defaults = {
   flutter_path = nil,
-  flutter_lookup_cmd = utils.is_linux and "flutter sdk-path" or nil,
+  flutter_lookup_cmd = path.is_linux and "flutter sdk-path" or nil,
   widget_guides = {
     enabled = false,
     debug = false
@@ -71,13 +70,14 @@ local deprecations = {
 }
 
 local function handle_deprecation(key, value, config)
+  local echomsg = require("flutter-tools.utils").echomsg
   local deprecation = deprecations[key]
   if not deprecation then
     return
   end
   vim.defer_fn(
     function()
-      utils.echomsg(fmt("%s is deprecated: %s", key, deprecation.message), "WarningMsg")
+      echomsg(fmt("%s is deprecated: %s", key, deprecation.message), "WarningMsg")
     end,
     1000
   )

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -21,6 +21,10 @@ local function get_split_cmd(percentage, fallback)
   return string.format("botright %dvnew", math.max(vim.o.columns * percentage, fallback))
 end
 
+M.debug_levels = {
+  DEBUG = 1
+}
+
 local defaults = {
   flutter_path = nil,
   flutter_lookup_cmd = utils.is_linux and "flutter sdk-path" or nil,
@@ -34,6 +38,9 @@ local defaults = {
   closing_tags = {
     highlight = "Comment",
     prefix = "// "
+  },
+  lsp = {
+    debug = M.debug_levels.DEBUG
   },
   outline = setmetatable(
     {},
@@ -91,6 +98,9 @@ function M.set(user_config)
   end
   for key, value in pairs(user_config) do
     handle_deprecation(key, value, user_config)
+    if user_config[key] and type(user_config[key]) == "table" then
+      setmetatable(user_config[key], {__index = defaults[key]})
+    end
   end
   validate_prefs(user_config)
   config = setmetatable(user_config, {__index = defaults})

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -21,7 +21,8 @@ local function get_split_cmd(percentage, fallback)
 end
 
 M.debug_levels = {
-  DEBUG = 1
+  DEBUG = 1,
+  WARN = 2
 }
 
 local defaults = {
@@ -39,7 +40,7 @@ local defaults = {
     prefix = "// "
   },
   lsp = {
-    debug = M.debug_levels.DEBUG
+    debug = M.debug_levels.WARN
   },
   outline = setmetatable(
     {},

--- a/lua/flutter-tools/dap.lua
+++ b/lua/flutter-tools/dap.lua
@@ -1,4 +1,5 @@
 local utils = require("flutter-tools.utils")
+local path = require("flutter-tools.utils.path")
 
 local success, dap = pcall(require, "dap")
 if not success then
@@ -13,8 +14,8 @@ local fmt = string.format
 local M = {}
 
 local dart_code_git = "https://github.com/Dart-Code/Dart-Code.git"
-local debugger_dir = utils.join {fn.stdpath("cache"), "dart-code"}
-local debugger_path = utils.join {debugger_dir, "out", "dist", "debug.js"}
+local debugger_dir = path.join(fn.stdpath("cache"), "dart-code")
+local debugger_path = path.join(debugger_dir, "out", "dist", "debug.js")
 
 ---Install the dart code debugger into neovim’s cache directory
 ---@param silent boolean whether or not to warn if already installed

--- a/lua/flutter-tools/dap.lua
+++ b/lua/flutter-tools/dap.lua
@@ -1,5 +1,4 @@
 local utils = require("flutter-tools.utils")
-local executable = require("flutter-tools.executable")
 
 local success, dap = pcall(require, "dap")
 if not success then
@@ -42,6 +41,7 @@ end
 function M.setup(_)
   M.install_debugger(true)
 
+  local executable = require("flutter-tools.executable")
   local flutter_sdk_path = executable.flutter_sdk_path
   local dart_sdk_path = executable.dart_sdk_root_path()
 

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -58,7 +58,7 @@ function M.start()
       fn.jobstart(
       table.concat(
         {
-          executable.get_flutter(),
+          executable.paths.flutter_bin,
           "pub",
           "global",
           "run",

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -1,4 +1,5 @@
 local utils = require("flutter-tools.utils")
+local path = require("flutter-tools.utils.path")
 local ui = require("flutter-tools.ui")
 
 local fn = vim.fn
@@ -33,8 +34,8 @@ local function get_paths()
     local flutter_sdk_path = utils.remove_newlines(fn.system(conf.flutter_lookup_cmd))
     if not has_shell_error() then
       return {
-        dart_bin = utils.join {flutter_sdk_path, "bin", "dart"},
-        flutter_bin = utils.join {flutter_sdk_path, "bin", "flutter"},
+        dart_bin = path.join(flutter_sdk_path, "bin", "dart"),
+        flutter_bin = path.join(flutter_sdk_path, "bin", "flutter"),
         flutter_sdk = flutter_sdk_path
       }
     else
@@ -47,30 +48,30 @@ end
 
 M.paths = get_paths()
 
-local dart_sdk = utils.join {"cache", "dart-sdk"}
+local dart_sdk = path.join("cache", "dart-sdk")
 
 function M.dart_sdk_root_path(user_bin_path)
   if user_bin_path then
-    return utils.join {user_bin_path, dart_sdk}
+    return path.join(user_bin_path, dart_sdk)
   end
 
   if utils.executable("flutter") then
     if M.paths.flutter_sdk then
       -- On Linux installations with snap the dart SDK can be further nested inside a bin directory
       -- so it's /bin/cache/dart-sdk whereas else where it is /cache/dart-sdk
-      local paths = {M.paths.flutter_sdk, "cache"}
-      if not utils.is_dir(utils.join(paths)) then
-        table.insert(paths, 2, "bin")
+      local segments = {M.paths.flutter_sdk, "cache"}
+      if not path.is_dir(path.join(unpack(segments))) then
+        table.insert(segments, 2, "bin")
       end
-      if utils.is_dir(utils.join(paths)) then
+      if path.is_dir(path.join(unpack(segments))) then
         -- remove the /cache/ directory as it's already part of the SDK path above
-        paths[#paths] = nil
-        return utils.join(vim.tbl_flatten {paths, dart_sdk})
+        segments[#segments] = nil
+        return path.join(unpack(vim.tbl_flatten {segments, dart_sdk}))
       end
     else
       local flutter_path = fn.resolve(fn.exepath("flutter"))
       local flutter_bin = fn.fnamemodify(flutter_path, ":h")
-      return utils.join {flutter_bin, dart_sdk}
+      return path.join(flutter_bin, dart_sdk)
     end
   end
 

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -85,7 +85,7 @@ end
 ---Prefix a command with the flutter executable
 ---@param cmd string
 function M.with(cmd)
-  return M.paths .. " " .. cmd
+  return M.paths.flutter_bin .. " " .. cmd
 end
 
 return M

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -1,46 +1,11 @@
-local config = require("flutter-tools.config")
 local utils = require("flutter-tools.utils")
 local ui = require("flutter-tools.ui")
 
 local fn = vim.fn
 
 local M = {
-  dart_bin_name = "dart",
-  dart_bin_path = nil,
-  flutter_bin_path = nil,
-  flutter_sdk_path = nil
+  dart_bin_name = "dart"
 }
-
-local dart_sdk = utils.join {"cache", "dart-sdk"}
-
-function M.dart_sdk_root_path(user_bin_path)
-  if user_bin_path then
-    return utils.join {user_bin_path, dart_sdk}
-  elseif utils.executable("flutter") then
-    local _, flutter_sdk = M.get_flutter()
-    if flutter_sdk then
-      -- On Linux installations with snap the dart SDK can be further nested inside a bin directory
-      -- so it's /bin/cache/dart-sdk whereas else where it is /cache/dart-sdk
-      local paths = {flutter_sdk, "cache"}
-      if not utils.is_dir(utils.join(paths)) then
-        table.insert(paths, 2, "bin")
-      end
-      if utils.is_dir(utils.join(paths)) then
-        -- remove the /cache/ directory as it's already part of the SDK path above
-        paths[#paths] = nil
-        return utils.join(vim.tbl_flatten {paths, dart_sdk})
-      end
-    else
-      local flutter_path = fn.resolve(fn.exepath("flutter"))
-      local flutter_bin = fn.fnamemodify(flutter_path, ":h")
-      return utils.join {flutter_bin, dart_sdk}
-    end
-  elseif utils.executable("dart") then
-    return fn.resolve(fn.exepath("dart"))
-  else
-    return ""
-  end
-end
 
 local function has_shell_error()
   return vim.v.shell_error > 0 or vim.v.shell_error == -1
@@ -56,36 +21,70 @@ end
 ---Fetch the path to the users flutter installation.
 ---NOTE: this should not be called before the plugin
 ---setup has occurred
----@return string
-function M.get_flutter()
-  if M.flutter_bin_path then
-    return M.flutter_bin_path
+---@return table<string, string>
+local function get_paths()
+  local conf = require("flutter-tools.config").get()
+
+  if conf.flutter_path then
+    return {flutter_bin = conf.flutter_path}
   end
 
-  local _config = config.get()
-  if _config.flutter_path then
-    M.flutter_bin_path = _config.flutter_path
-  elseif _config.flutter_lookup_cmd then
-    M.flutter_sdk_path = utils.remove_newlines(fn.system(_config.flutter_lookup_cmd))
-
+  if conf.flutter_lookup_cmd then
+    local flutter_sdk_path = utils.remove_newlines(fn.system(conf.flutter_lookup_cmd))
     if not has_shell_error() then
-      M.dart_bin_path = utils.join {M.flutter_sdk_path, "bin", "dart"}
-      M.flutter_bin_path = utils.join {M.flutter_sdk_path, "bin", "flutter"}
+      return {
+        dart_bin = utils.join {flutter_sdk_path, "bin", "dart"},
+        flutter_bin = utils.join {flutter_sdk_path, "bin", "flutter"},
+        flutter_sdk = flutter_sdk_path
+      }
     else
-      ui.notify({string.format("Error running %s", _config.flutter_lookup_cmd)})
-      M.flutter_bin_path, M.dart_bin_path = get_default_binaries()
+      ui.notify({string.format("Error running %s", conf.flutter_lookup_cmd)})
     end
-  else
-    M.flutter_bin_path, M.dart_bin_path = get_default_binaries()
+  end
+  local flutter_bin, dart_bin = get_default_binaries()
+  return {flutter_bin = flutter_bin, dart_bin = dart_bin}
+end
+
+M.paths = get_paths()
+
+local dart_sdk = utils.join {"cache", "dart-sdk"}
+
+function M.dart_sdk_root_path(user_bin_path)
+  if user_bin_path then
+    return utils.join {user_bin_path, dart_sdk}
   end
 
-  return M.flutter_bin_path, M.flutter_sdk_path
+  if utils.executable("flutter") then
+    if M.paths.flutter_sdk then
+      -- On Linux installations with snap the dart SDK can be further nested inside a bin directory
+      -- so it's /bin/cache/dart-sdk whereas else where it is /cache/dart-sdk
+      local paths = {M.paths.flutter_sdk, "cache"}
+      if not utils.is_dir(utils.join(paths)) then
+        table.insert(paths, 2, "bin")
+      end
+      if utils.is_dir(utils.join(paths)) then
+        -- remove the /cache/ directory as it's already part of the SDK path above
+        paths[#paths] = nil
+        return utils.join(vim.tbl_flatten {paths, dart_sdk})
+      end
+    else
+      local flutter_path = fn.resolve(fn.exepath("flutter"))
+      local flutter_bin = fn.fnamemodify(flutter_path, ":h")
+      return utils.join {flutter_bin, dart_sdk}
+    end
+  end
+
+  if utils.executable("dart") then
+    return fn.resolve(fn.exepath("dart"))
+  end
+
+  return ""
 end
 
 ---Prefix a command with the flutter executable
 ---@param cmd string
 function M.with(cmd)
-  return M.get_flutter() .. " " .. cmd
+  return M.paths .. " " .. cmd
 end
 
 return M

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -3,46 +3,114 @@ local labels = require("flutter-tools.labels")
 local outline = require("flutter-tools.outline")
 local guides = require("flutter-tools.guides")
 
+local api = vim.api
+local lsp = vim.lsp
+local fn = vim.fn
+local fmt = string.format
+
+local FILETYPE = "dart"
+
 local M = {
-  initialised = false
+  lsps = {}
 }
 
-local function analysis_server_snapshot_path(dart_sdk_path)
-  return utils.join {dart_sdk_path, "bin", "snapshots", "analysis_server.dart.snapshot"}
+local function analysis_server_snapshot_path(sdk_path)
+  return utils.join {sdk_path, "bin", "snapshots", "analysis_server.dart.snapshot"}
 end
 
-function M.setup(user_config)
-  local config = (user_config and user_config.lsp) and user_config.lsp or {}
-  if M.initialised then
-    return utils.echomsg [[DartLS has already been setup!]]
-  end
-  local success, lspconfig = pcall(require, "lspconfig")
-  if not success or not lspconfig then
-    utils.echomsg("You must have the neovim/nvim-lspconfig module installed", "Error")
-    return
-  end
-
-  local cfg = {
-    init_options = {
-      closingLabels = true,
-      outline = true,
-      flutterOutline = true
-    },
-    handlers = {
-      ["dart/textDocument/publishClosingLabels"] = labels.closing_tags,
-      ["dart/textDocument/publishOutline"] = outline.document_outline,
-      ["dart/textDocument/publishFlutterOutline"] = guides.widget_guides
+function M.setup()
+  require("flutter-tools.utils").augroup(
+    "FlutterToolsLsp",
+    {
+      {
+        events = {"FileType"},
+        targets = {"dart"},
+        command = "lua require('flutter-tools.lsp').attach()"
+      }
     }
-  }
-  if user_config.experimental.lsp_derive_paths then
-    local executable = require("flutter-tools.executable")
-    local dart_sdk_path = executable.dart_sdk_root_path()
-    cfg.cmd = {executable.dart_bin_name, analysis_server_snapshot_path(dart_sdk_path), "--lsp"}
+  )
+end
+
+local function merge_config(default, user)
+  return vim.tbl_deep_extend("force", default or {}, user or {})
+end
+
+local function create_debug_log(level)
+  return function(msg)
+    local levels = require("flutter-tools.config").debug_levels
+    if level >= levels.DEBUG then
+      utils.echomsg(msg)
+    end
+  end
+end
+
+function M.attach()
+  local conf = require("flutter-tools.config").get()
+  local user_config = conf.lsp or {}
+  local debug_log = create_debug_log(user_config.debug)
+
+  debug_log("attaching LSP")
+
+  local config = utils.merge({name = "dartls"}, user_config)
+
+  local bufnr = api.nvim_get_current_buf()
+  -- local bufname = api.nvim_buf_get_name(bufnr)
+
+  -- Check to see if dartls is already attached, and if so attatch
+  for _, buf in pairs(vim.fn.getbufinfo({bufloaded = true})) do
+    if api.nvim_buf_get_option(buf.bufnr, "filetype") == FILETYPE then
+      local clients = lsp.buf_get_clients(buf.bufnr)
+      for _, client in ipairs(clients) do
+        if client.config.name == config.name then
+          lsp.buf_attach_client(bufnr, client.id)
+          return true
+        end
+      end
+    end
   end
 
-  config = vim.tbl_deep_extend("force", cfg, config)
-  lspconfig.dartls.setup(config)
-  M.initialised = true
+  config.filetypes = {FILETYPE}
+
+  local executable = require("flutter-tools.executable")
+  local path = executable.dart_sdk_root_path()
+
+  debug_log(fmt("dart_sdk_path: %s", path))
+
+  config.cmd = {executable.dart_bin_name, analysis_server_snapshot_path(path), "--lsp"}
+  config.root_patterns = config.root_patterns or {".git", "pubspec.yaml"}
+
+  -- util.find_root_dir(config.root_patterns, bufname) or
+  config.root_dir = fn.expand("%:p:h")
+  config.capabilities = merge_config(lsp.protocol.make_client_capabilities(), config.capabilities)
+  config.capabilities = merge_config(config.capabilities, {workspace = {configuration = true}})
+
+  config.init_options = {
+    onlyAnalyzeProjectsWithOpenFiles = false,
+    suggestFromUnimportedLibraries = true,
+    closingLabels = true,
+    outline = true,
+    flutterOutline = true
+  }
+
+  config.handlers = {
+    ["dart/textDocument/publishClosingLabels"] = labels.closing_tags,
+    ["dart/textDocument/publishOutline"] = outline.document_outline,
+    ["dart/textDocument/publishFlutterOutline"] = guides.widget_guides
+  }
+
+  local settings = config.settings or {}
+
+  config.on_init = function(client, _)
+    return client.notify("workspace/didChangeConfiguration", {settings = settings})
+  end
+
+  local client_id = M.lsps[config.root_dir]
+  if not client_id then
+    client_id = lsp.start_client(config)
+    M.lsps[config.root_dir] = client_id
+  end
+
+  lsp.buf_attach_client(bufnr, client_id)
 end
 
 return M

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -70,7 +70,6 @@ function M.attach()
   local config = utils.merge({name = "dartls"}, user_config)
 
   local bufnr = api.nvim_get_current_buf()
-  -- local bufname = api.nvim_buf_get_name(bufnr)
 
   -- Check to see if dartls is already attached, and if so attatch
   for _, buf in pairs(vim.fn.getbufinfo({bufloaded = true})) do
@@ -95,8 +94,8 @@ function M.attach()
   config.cmd = {executable.dart_bin_name, analysis_server_snapshot_path(root_path), "--lsp"}
   config.root_patterns = config.root_patterns or {".git", "pubspec.yaml"}
 
-  -- util.find_root_dir(config.root_patterns, bufname) or
-  config.root_dir = fn.expand("%:p:h")
+  local current_dir = fn.expand("%:p:h")
+  config.root_dir = path.find_root(config.root_patterns, current_dir) or current_dir
 
   config.capabilities = merge_config(lsp.protocol.make_client_capabilities(), config.capabilities)
   config.capabilities = merge_config(config.capabilities, {workspace = {configuration = true}})

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -1,4 +1,5 @@
 local utils = require("flutter-tools.utils")
+local path = require("flutter-tools.utils.path")
 
 local api = vim.api
 local lsp = vim.lsp
@@ -12,7 +13,7 @@ local M = {
 }
 
 local function analysis_server_snapshot_path(sdk_path)
-  return utils.join {sdk_path, "bin", "snapshots", "analysis_server.dart.snapshot"}
+  return path.join(sdk_path, "bin", "snapshots", "analysis_server.dart.snapshot")
 end
 
 function M.setup()
@@ -87,11 +88,11 @@ function M.attach()
   config.filetypes = {FILETYPE}
 
   local executable = require("flutter-tools.executable")
-  local path = executable.dart_sdk_root_path()
+  local root_path = executable.dart_sdk_root_path()
 
-  debug_log(fmt("dart_sdk_path: %s", path))
+  debug_log(fmt("dart_sdk_path: %s", root_path))
 
-  config.cmd = {executable.dart_bin_name, analysis_server_snapshot_path(path), "--lsp"}
+  config.cmd = {executable.dart_bin_name, analysis_server_snapshot_path(root_path), "--lsp"}
   config.root_patterns = config.root_patterns or {".git", "pubspec.yaml"}
 
   -- util.find_root_dir(config.root_patterns, bufname) or

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -45,7 +45,7 @@ end
 local function get_defaults()
   return {
     init_options = {
-      onlyAnalyzeProjectsWithOpenFiles = false,
+      onlyAnalyzeProjectsWithOpenFiles = true,
       suggestFromUnimportedLibraries = true,
       closingLabels = true,
       outline = true,

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -29,7 +29,14 @@ function M.setup()
   )
 end
 
+---Merge a set of default configurations with a user's own settings
+---@param default table
+---@param user table
+---@return table
 local function merge_config(default, user)
+  if not user or vim.tbl_isempty(user) then
+    return default
+  end
   return vim.tbl_deep_extend("force", default or {}, user or {})
 end
 

--- a/lua/flutter-tools/lsp.lua
+++ b/lua/flutter-tools/lsp.lua
@@ -115,7 +115,7 @@ function M.attach()
   config.capabilities = merge_config(defaults.capabilities, config.capabilities)
   config.init_options = merge_config(defaults.init_options, config.init_options)
   config.handlers = merge_config(defaults.handlers, config.handlers)
-  config.settings = merge_config(defaults.settings, config.settings)
+  config.settings = merge_config(defaults.settings, {dart = config.settings})
 
   config.on_init = function(client, _)
     return client.notify("workspace/didChangeConfiguration", {settings = config.settings})

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -100,19 +100,6 @@ function M.merge(t1, t2)
   return t1
 end
 
----Join segments of a path into a full path with
----the correct separator
----@param segments string[]
-function M.join(segments)
-  return table.concat(segments, M.sep)
-end
-
-local sys_name = vim.loop.os_uname().sysname
-M.is_linux = sys_name == "Linux"
-M.is_windows = fn.has("win32") == 1 or fn.has("win64") == 1
-
-M.sep = fn.has("win32") == 1 or fn.has("win64") == 1 and "\\" or "/"
-
 function M.remove_newlines(str)
   if not str or type(str) ~= "string" then
     return str
@@ -120,16 +107,8 @@ function M.remove_newlines(str)
   return str:gsub("[\n\r]", "")
 end
 
-function M.format_path(path)
-  return M.is_windows and path:gsub("/", "\\") or path
-end
-
 function M.executable(bin)
   return fn.executable(bin) > 0
-end
-
-function M.is_dir(path)
-  return fn.isdirectory(path) > 0
 end
 
 ---Get the attribute value of a specified highlight

--- a/lua/flutter-tools/utils/path.lua
+++ b/lua/flutter-tools/utils/path.lua
@@ -1,0 +1,123 @@
+local luv = vim.loop
+
+-- Some path utilities
+local function exists(filename)
+  local stat = luv.fs_stat(filename)
+  return stat and stat.type or false
+end
+
+local function is_dir(filename)
+  return exists(filename) == "directory"
+end
+
+local function is_file(filename)
+  return exists(filename) == "file"
+end
+
+local is_linux = luv.os_uname().sysname == "Linux"
+local is_windows = luv.os_uname().version:match("Windows")
+local path_sep = is_windows and "\\" or "/"
+
+local is_fs_root
+if is_windows then
+  is_fs_root = function(path)
+    return path:match("^%a:$")
+  end
+else
+  is_fs_root = function(path)
+    return path == "/"
+  end
+end
+
+local function is_absolute(filename)
+  if is_windows then
+    return filename:match("^%a:") or filename:match("^\\\\")
+  else
+    return filename:match("^/")
+  end
+end
+
+local dirname
+do
+  local strip_dir_pat = path_sep .. "([^" .. path_sep .. "]+)$"
+  local strip_sep_pat = path_sep .. "$"
+  dirname = function(path)
+    if not path then
+      return
+    end
+    local result = path:gsub(strip_sep_pat, ""):gsub(strip_dir_pat, "")
+    if #result == 0 then
+      return "/"
+    end
+    return result
+  end
+end
+
+local function path_join(...)
+  local result = table.concat(vim.tbl_flatten {...}, path_sep):gsub(path_sep .. "+", path_sep)
+  return result
+end
+
+-- Traverse the path calling cb along the way.
+local function traverse_parents(path, cb)
+  path = luv.fs_realpath(path)
+  local dir = path
+  -- Just in case our algo is buggy, don't infinite loop.
+  for _ = 1, 100 do
+    dir = dirname(dir)
+    if not dir then
+      return
+    end
+    -- If we can't ascend further, then stop looking.
+    if cb(dir, path) then
+      return dir, path
+    end
+    if is_fs_root(dir) then
+      break
+    end
+  end
+end
+
+-- Iterate the path until we find the rootdir.
+local function iterate_parents(path)
+  path = luv.fs_realpath(path)
+  local function it(_, v)
+    if not v then
+      return
+    end
+    if is_fs_root(v) then
+      return
+    end
+    return dirname(v), path
+  end
+  return it, path, path
+end
+
+local function is_descendant(root, path)
+  if (not path) then
+    return false
+  end
+
+  local function cb(dir, _)
+    return dir == root
+  end
+
+  local dir, _ = traverse_parents(path, cb)
+
+  return dir == root
+end
+
+return {
+  is_dir = is_dir,
+  is_file = is_file,
+  is_absolute = is_absolute,
+  exists = exists,
+  sep = path_sep,
+  dirname = dirname,
+  join = path_join,
+  traverse_parents = traverse_parents,
+  iterate_parents = iterate_parents,
+  is_descendant = is_descendant,
+  is_windows = is_windows,
+  is_linux = is_linux,
+}


### PR DESCRIPTION
lspconfig is a thin wrapper around starting an lsp server which in actuality isn't that tough to do without it. So this PR removes the dependency since it is not absolutely necessary. Whilst very likely users will have it installed it isn't guaranteed. Also this seems like it gives me more direct control over the lsp server so functionality or configurations won't change underfoot.

EDIT: also tbh I wanted to get more familiar with the native lsp functionality rather than work with/around an abstraction layer