### PR TITLE
fix: ignore invalid end indices

### DIFF
--- a/lua/flutter-tools/guides.lua
+++ b/lua/flutter-tools/guides.lua
@@ -101,8 +101,9 @@ local function collect_guides(lines, data, guides)
     for lnum = start_lnum, end_lnum, 1 do
       -- TODO: skip empty lines since currently extmarks,
       -- cannot be set where there is no existing text
-      if lines[lnum + 1] ~= "" then
-        local end_index = first_marker_index(lines, lnum, END_OFFSET)
+      -- 2. if we get an invalid end index don't bother trying to draw guides
+      local end_index = first_marker_index(lines, lnum, END_OFFSET)
+      if lines[lnum + 1] ~= "" and end_index ~= -1 then
         local indent_size = end_index - start_index
         indent_size = indent_size > 0 and indent_size - 1 or indent_size
 
@@ -145,7 +146,12 @@ local function render_guides(bufnum, guides, conf)
         local name = api.nvim_buf_get_name(bufnum)
         utils.echomsg({
           {
-            fmt("error drawing widget guide for %s at line %d, col %d\n", name, lnum, start),
+            fmt(
+              "error drawing widget guide for %s at line %d, col %d\n",
+              name,
+              lnum,
+              start
+            ),
             "Title",
           },
           { msg, "ErrorMsg" },


### PR DESCRIPTION
Sometimes for reasons I don't understand properly yet the lsp guide ranges are not valid and so no matching character can be found to use for drawing the widgets on a line so for now we omit these