### PR TITLE
fix: derive flutter sdk path from flutter_path

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -102,7 +102,7 @@ local function _dart_sdk_root(paths)
     end
   end
 
-  if utils.executable("dart") then
+  if utils.executable("flutter") then
     local flutter_path = fn.resolve(fn.exepath("flutter"))
     local flutter_bin = fn.fnamemodify(flutter_path, ":h")
     return path.join(flutter_bin, dart_sdk)

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -63,7 +63,11 @@ function M.get(callback)
   end
 
   if conf.flutter_path then
-    _paths = { flutter_bin = conf.flutter_path }
+    _paths = {
+      flutter_bin = conf.flutter_path,
+      -- convert path/to/flutter/bin/flutter into path/to/flutter
+      flutter_sdk = fn.fnamemodify(conf.flutter_path, ":h:h"),
+    }
     return callback(_paths.flutter_bin, _paths)
   end
 
@@ -84,24 +88,24 @@ end
 local dart_sdk = path.join("cache", "dart-sdk")
 
 local function _dart_sdk_root(paths)
-  if utils.executable("flutter") then
-    if paths.flutter_sdk then
-      -- On Linux installations with snap the dart SDK can be further nested inside a bin directory
-      -- so it's /bin/cache/dart-sdk whereas else where it is /cache/dart-sdk
-      local segments = { paths.flutter_sdk, "cache" }
-      if not path.is_dir(path.join(unpack(segments))) then
-        table.insert(segments, 2, "bin")
-      end
-      if path.is_dir(path.join(unpack(segments))) then
-        -- remove the /cache/ directory as it's already part of the SDK path above
-        segments[#segments] = nil
-        return path.join(unpack(vim.tbl_flatten({ segments, dart_sdk })))
-      end
-    else
-      local flutter_path = fn.resolve(fn.exepath("flutter"))
-      local flutter_bin = fn.fnamemodify(flutter_path, ":h")
-      return path.join(flutter_bin, dart_sdk)
+  if paths.flutter_sdk then
+    -- On Linux installations with snap the dart SDK can be further nested inside a bin directory
+    -- so it's /bin/cache/dart-sdk whereas else where it is /cache/dart-sdk
+    local segments = { paths.flutter_sdk, "cache" }
+    if not path.is_dir(path.join(unpack(segments))) then
+      table.insert(segments, 2, "bin")
     end
+    if path.is_dir(path.join(unpack(segments))) then
+      -- remove the /cache/ directory as it's already part of the SDK path above
+      segments[#segments] = nil
+      return path.join(unpack(vim.tbl_flatten({ segments, dart_sdk })))
+    end
+  end
+
+  if utils.executable("dart") then
+    local flutter_path = fn.resolve(fn.exepath("flutter"))
+    local flutter_bin = fn.fnamemodify(flutter_path, ":h")
+    return path.join(flutter_bin, dart_sdk)
   end
 
   if utils.executable("dart") then
@@ -120,7 +124,7 @@ function M.dart_sdk_root_path(callback, user_bin_path)
     "A function callback must be passed in"
   )
   if user_bin_path then
-    callback(path.join(user_bin_path, dart_sdk))
+    return callback(path.join(user_bin_path, dart_sdk))
   end
 
   M.get(function(_, paths)


### PR DESCRIPTION
This PR removes checks for flutter to be executable via the user's `PATH` despite them having passed in an absolute path, it instead attempts to derive the flutter sdk path from the binary path

should fix #30 