### PR TITLE
Add command to copy profiler url

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ NOTE: To configure the highlight colour you can override the `FlutterWidgetGuide
 - `FlutterOutline` - Opens an outline window showing the widget tree for the given file.
 - `FlutterDevTools` - Starts a Dart Dev Tools server.
 - `FlutterCopyProfilerUrl` - Copies the profiler url to your system clipboard (+ register). Note that commands `FlutterRun` and
-`FlutterDevTolls` must be executed first.
+`FlutterDevTools` must be executed first.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,13 @@ NOTE: To configure the highlight colour you can override the `FlutterWidgetGuide
 - `FlutterRun` - Run the current project. This needs to be run from within a flutter project.
 - `FlutterDevices` - Brings up a list of connected devices to select from.
 - `FlutterEmulators` - Similar to devices but shows a list of emulators to choose from.
-- `FlutterReload` - Reload the running project
-- `FlutterRestart` - Restart the current project
-- `FlutterQuit` - Ends a running session
-- `FlutterOutline` - Opens an outline window showing the widget tree for the given file
+- `FlutterReload` - Reload the running project.
+- `FlutterRestart` - Restart the current project.
+- `FlutterQuit` - Ends a running session.
+- `FlutterOutline` - Opens an outline window showing the widget tree for the given file.
+- `FlutterDevTools` - Starts a Dart Dev Tools server.
+- `FlutterCopyProfilerUrl` - Copies the profiler url to your system clipboard (+ register). Note that commands `FlutterRun` and
+`FlutterDevTolls` must be executed first.
 
 ## Debugging
 

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -16,6 +16,7 @@ local function setup_commands()
   utils.command("FlutterOutline", [[lua require('flutter-tools.outline').open()]])
   --- Dev tools
   utils.command("FlutterDevTools", [[lua require('flutter-tools.dev_tools').start()]])
+  utils.command("FlutterCopyProfilerUrl", [[lua require('flutter-tools.commands').copy_profiler_url()]])
   --- Log
   utils.command("FlutterLogClear", [[lua require('flutter-tools.log').clear()]])
 end

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -10,6 +10,9 @@ local fn = vim.fn
 ---@type Job
 local job = nil
 
+---@type string
+local devtools_url = nil;
+
 local activate_cmd = { "pub", "global", "activate", "devtools" }
 
 --[[ {
@@ -30,8 +33,8 @@ local function handle_start(_, data, __)
   if #data > 0 then
     local json = fn.json_decode(data)
     if json and json.params then
-      local msg =
-        string.format("Serving DevTools at http://%s:%s", json.params.host, json.params.port)
+      devtools_url = string.format("http://%s:%s", json.params.host, json.params.port)
+      local msg = string.format("Serving DevTools at %s", devtools_url)
       ui.notify({ msg }, 20000)
     end
   end
@@ -84,6 +87,11 @@ function M.start()
   else
     utils.echomsg("DevTools are already running!")
   end
+end
+
+---@return string
+function M.get_url()
+  return devtools_url
 end
 
 return M

--- a/lua/flutter-tools/menu.lua
+++ b/lua/flutter-tools/menu.lua
@@ -111,6 +111,13 @@ function M.commands(opts)
       command = require("flutter-tools.dev_tools").start,
     },
     {
+      id = "flutter-tools-copy-profiler-url",
+      label = "Flutter tools: Copy Profiler Url",
+      hint = "Run the app and the DevTools first",
+      command = require("flutter-tools.commands").copy_profiler_url,
+    },
+
+    {
       id = "flutter-tools-clear-dev-log",
       label = "Flutter tools: Clear Dev Log",
       hint = "Clear previous logs in the output buffer",


### PR DESCRIPTION
This PR adds a command to copy the profiler url to the clipboard.
In order to execute the command the app and our own DevTools server must be running (FlutterRun + FlutterCopyProfilerUrl commands)

- [X] Command implemented
- [X] Command registered in the `setup_commands` function
- [X] Command added to the telescope menu
- [x] Documentation updated

### Concerns
I've found the following issues while working on this
- As mentioned here, #9 there are some issues with how the DevTools are managed: We don't stop the process. Would be great to have a way to reuse an existing dart devtools process if it's already running and gather its info.
- Chrome and Android have different console outputs regarding the profiler url as mentioned in the [`search_profiler_url`](https://github.com/akinsho/flutter-tools.nvim/compare/main...Charly6596:copy-devtools-link?expand=1#diff-96c4b32009844045b7f1ce3515556a45d330b4b0c2567fa9fed85d0efb0a782fR27) comments. The Android execution runs another dart tools process and outputs an already formatted link to the profiler. The `flutter run` command has a flag to specify the dev tools url, `--devtools-server-address`. We could (optionally) start our own devtools server before starting the app and use it to have more control over it.
- Commands that shouldn't be executed are shown in the menu without any distinction. I'm talking about reloading, restarting the app while the app is not running for example. In `coc-flutter` they hide those commands, wonder if something similar could be done, something like marking the commands as not executable