### PR TITLE
fix devtools processes

### DIFF
--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -1,8 +1,8 @@
-local utils = require("flutter-tools.utils")
 
 local M = {}
 
 local function setup_commands()
+  local utils = require("flutter-tools.utils")
   -- Commands
   utils.command("FlutterRun", [[lua require('flutter-tools.commands').run()]])
   utils.command("FlutterReload", [[lua require('flutter-tools.commands').reload()]])
@@ -25,6 +25,7 @@ local function setup_commands()
 end
 
 local function setup_autocommands()
+  local utils = require("flutter-tools.utils")
   utils.augroup("FlutterToolsHotReload", {
     {
       events = { "BufWritePost" },

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -25,7 +25,7 @@ local function setup_commands()
 end
 
 local function setup_autocommands()
-  require("flutter-tools.utils").augroup("FlutterToolsHotReload", {
+  utils.augroup("FlutterToolsHotReload", {
     {
       events = { "BufWritePost" },
       targets = { "*.dart" },
@@ -41,6 +41,14 @@ local function setup_autocommands()
       targets = { require("flutter-tools.log").filename },
       command = "lua require('flutter-tools.log').__resurrect()",
     },
+  })
+
+  utils.augroup("FlutterToolsOnClose", {
+    {
+      events = { "VimLeavePre" },
+      targets = { "*" },
+      command = "lua require('flutter-tools.dev_tools').stop()"
+    }
   })
 end
 

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -57,6 +57,7 @@ end
 ---@param user_config table
 ---@return nil
 function M.setup(user_config)
+  local utils = require("flutter-tools.utils")
   local success = pcall(require, "plenary")
   if not success then
     return utils.echomsg("plenary.nvim is a required dependency of this plugin, please ensure it is installed")

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -172,7 +172,7 @@ function M.copy_profiler_url()
     vim.cmd("let @+='" .. url .. "'")
     ui.notify({ "Profiler url copied to clipboard!" })
   elseif is_running then
-    ui.notify({ "Wait while the app starts", "and again later" })
+    ui.notify({ "Wait while the app starts", "please try again later" })
   else
     ui.notify({ "You must start the DevTools server first!" })
   end

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -126,6 +126,11 @@ function M.run(device)
     if device and device.id then
       vim.list_extend(args, { "-d", device.id })
     end
+
+    local dev_url = dev_tools.get_url()
+    if dev_url then
+      vim.list_extend(args, { "--devtools-server-address", dev_url })
+    end
     ui.notify({ "Starting flutter project..." })
     local conf = config.get("dev_log")
     run_job = Job:new({

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -14,34 +14,6 @@ local M = {}
 ---@type Job
 local run_job = nil
 
----@type string
-local profiler_url = nil
-
----@param data string
-local function search_profiler_url(data)
-  -- We already have it, stop checking messages
-  if profiler_url then
-    return
-  end
-
-  -- Chrome
-  -- Debug service listening on ws://127.0.0.1:44293/heXbxLM_lhM=/ws
-  local m = data:match("Debug service listening on (ws%:%/%/127%.0%.0%.1%:%d+/.+/ws)$")
-  if not m then
-    -- Android
-    -- An Observatory debugger and profiler on sdk gphone x86 arm is available at: http://127.0.0.1:46051/NvCev-HjyX4=/
-    m =
-      data:match("An Observatory debugger and profiler on .+ is available at:%s(https?://127%.0%.0%.1:%d+/.+/)$")
-    -- Android when flutter run starts a new devtools process
-    -- Flutter DevTools, a Flutter debugger and profiler, on sdk gphone x86 arm is available at: http://127.0.0.1:9102?uri=http%3A%2F%2F127.0.0.1%3A46051%2FNvCev-HjyX4%3D%2F
-    -- m = data:match("Flutter DevTools, a Flutter debugger and profiler, on .+ is available at:%s(https?://127%.0%.0%.1:%d+%?uri=.+)$")
-  end
-
-  if m then
-    profiler_url = m
-  end
-end
-
 local function match_error_string(line)
   if not line then
     return false
@@ -77,7 +49,7 @@ local function on_run_data(is_err, opts)
       ui.notify({ data })
     end
     if not match_error_string(data) then
-      search_profiler_url(data)
+      dev_tools.handle_log(data)
       dev_log.log(data, opts)
     end
   end)
@@ -111,10 +83,7 @@ local function shutdown()
   if run_job then
     run_job = nil
   end
-
-  if profiler_url then
-    profiler_url = nil
-  end
+  dev_tools.on_flutter_shutdown()
 end
 
 function M.run(device)
@@ -197,18 +166,15 @@ function M.copy_profiler_url()
     return
   end
 
-  local dev_url = dev_tools.get_url()
-  if not dev_url then
-    ui.notify({ "You must start the DevTools server first!" })
-    return
-  end
+  local url, is_running = dev_tools.get_profiler_url()
 
-  if profiler_url then
-    local res = string.format("%s/?uri=%s", dev_url, profiler_url)
-    vim.cmd("let @+='" .. res .. "'")
+  if url then
+    vim.cmd("let @+='" .. url .. "'")
     ui.notify({ "Profiler url copied to clipboard!" })
+  elseif is_running then
+    ui.notify({ "Wait while the app starts", "and again later" })
   else
-    ui.notify({ "Could not find the profiler url", "Wait until the app is initialized" })
+    ui.notify({ "You must start the DevTools server first!" })
   end
 end
 

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -13,6 +13,9 @@ local job = nil
 ---@type string
 local devtools_url = nil
 
+---@type number
+local devtools_pid = nil
+
 local activate_cmd = { "pub", "global", "activate", "devtools" }
 
 --[[ {
@@ -33,6 +36,7 @@ local function handle_start(_, data, __)
   if #data > 0 then
     local json = fn.json_decode(data)
     if json and json.params then
+      devtools_pid = json.params.pid
       devtools_url = string.format("http://%s:%s", json.params.host, json.params.port)
       local msg = string.format("Serving DevTools at %s", devtools_url)
       ui.notify({ msg }, 20000)
@@ -86,6 +90,15 @@ function M.start()
     end)
   else
     utils.echomsg("DevTools are already running!")
+  end
+end
+
+function M.stop()
+  if devtools_pid then
+    local uv = vim.loop
+    uv.kill(devtools_pid, uv.constants.SIGTERM)
+    devtools_pid = nil
+    devtools_url = nil
   end
 end
 


### PR DESCRIPTION
Added an autocmd triggered when vim is closed to kill the devtools process if it was started by the user.
As mentioned in #41, the flutter run command starts a dev tools server if running on mobile and has a parameter to start an already running dev tools server url, so I check if we are running it and pass the url if so.

The autocmd could be used to cleanup other modules if needed.

There is an issue, if we are not running devtools and we start the app, if we wanted to copy the url we would need to start another devtools process with the command, we would have 2 processes, one manage by flutter and another by our plugin
I think we have 3 options
1. Keep it as it is.
2. Always run the dev tools server before running `flutter run` and pass the url as parameter
3. Let flutter start the server and pass its url it to the `dev_tools` module, preventing us from starting another server.

I prefer the second one myself but I would like to know what you think.