### PR TITLE
Hide disabled commands in telescope menu

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -17,6 +17,10 @@ local run_job = nil
 ---@type string
 local profiler_url = nil
 
+function M.is_running()
+  return run_job ~= nil
+end
+
 ---@param data string
 local function search_profiler_url(data)
   -- We already have it, stop checking messages

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -94,4 +94,9 @@ function M.get_url()
   return devtools_url
 end
 
+---@return boolean
+function M.is_running()
+  return devtools_url ~= nil
+end
+
 return M

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -180,4 +180,9 @@ function M.on_flutter_shutdown()
 
 end
 
+---@return boolean
+function M.is_running()
+  return devtools_profiler_url ~= nil and devtools_url ~= nil
+end
+
 return M

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -160,7 +160,8 @@ end
 
 ---@return boolean
 function M.is_running()
-  return devtools_profiler_url ~= nil or devtools_url ~= nil 
+  return devtools_profiler_url ~= nil or devtools_url ~= nil
+end
 
 ---@return string? devtools_profiler_url the url including the devtools url and the app url. Follows the format `devtools_url/?uri=app_url`
 ---@return boolean? server_running true if there is a `devtools_url` available but couldn't build the url
@@ -177,12 +178,6 @@ end
 function M.on_flutter_shutdown()
   profiler_url = nil
   devtools_profiler_url = nil
-
-end
-
----@return boolean
-function M.is_running()
-  return devtools_profiler_url ~= nil and devtools_url ~= nil
 end
 
 return M

--- a/lua/flutter-tools/menu.lua
+++ b/lua/flutter-tools/menu.lua
@@ -55,37 +55,48 @@ local function get_max_length(commands)
 end
 
 function M.commands(opts)
-  local commands = {
-    {
-      id = "flutter-tools-run",
-      label = "Flutter tools: Run",
-      hint = "Start a flutter project",
-      command = require("flutter-tools.commands").run,
-    },
-    {
-      id = "flutter-tools-hot-reload",
-      label = "Flutter tools: Hot reload",
-      hint = "Reload a running flutter project",
-      command = require("flutter-tools.commands").reload,
-    },
-    {
-      id = "flutter-tools-hot-restart",
-      label = "Flutter tools: Hot restart",
-      hint = "Restart a running flutter project",
-      command = require("flutter-tools.commands").restart,
-    },
-    {
-      id = "flutter-tools-quit",
-      label = "Flutter tools: Quit",
-      hint = "Quit running flutter project",
-      command = require("flutter-tools.commands").quit,
-    },
-    {
-      id = "flutter-tools-visual-debug",
-      label = "Flutter tools: Visual Debug",
-      hint = "Add the visual debugging overlay",
-      command = require("flutter-tools.commands").visual_debug,
-    },
+  local commands = { }
+
+  local commands_module = require("flutter-tools.commands")
+  if commands_module.is_running() then
+    commands = {
+      {
+        id = "flutter-tools-hot-reload",
+        label = "Flutter tools: Hot reload",
+        hint = "Reload a running flutter project",
+        command = require("flutter-tools.commands").reload,
+      },
+      {
+        id = "flutter-tools-hot-restart",
+        label = "Flutter tools: Hot restart",
+        hint = "Restart a running flutter project",
+        command = require("flutter-tools.commands").restart,
+      },
+      {
+        id = "flutter-tools-visual-debug",
+        label = "Flutter tools: Visual Debug",
+        hint = "Add the visual debugging overlay",
+        command = require("flutter-tools.commands").visual_debug,
+      },
+      {
+        id = "flutter-tools-quit",
+        label = "Flutter tools: Quit",
+        hint = "Quit running flutter project",
+        command = require("flutter-tools.commands").quit,
+      },
+    }
+  else
+    commands = {
+      {
+        id = "flutter-tools-run",
+        label = "Flutter tools: Run",
+        hint = "Start a flutter project",
+        command = require("flutter-tools.commands").run,
+      },
+    }
+  end
+
+  vim.list_extend(commands, {
     {
       id = "flutter-tools-list-devices",
       label = "Flutter tools: List Devices",
@@ -105,25 +116,34 @@ function M.commands(opts)
       command = require("flutter-tools.outline").open,
     },
     {
-      id = "flutter-tools-start-dev-tools",
-      label = "Flutter tools: Start Dev Tools",
-      hint = "Open flutter dev tools in the browser",
-      command = require("flutter-tools.dev_tools").start,
-    },
-    {
-      id = "flutter-tools-copy-profiler-url",
-      label = "Flutter tools: Copy Profiler Url",
-      hint = "Run the app and the DevTools first",
-      command = require("flutter-tools.commands").copy_profiler_url,
-    },
-
-    {
       id = "flutter-tools-clear-dev-log",
       label = "Flutter tools: Clear Dev Log",
       hint = "Clear previous logs in the output buffer",
       command = require("flutter-tools.log").clear,
     },
-  }
+  })
+
+  local dev_tools = require("flutter-tools.dev_tools")
+
+  if dev_tools.is_running() then
+      vim.list_extend(commands, {
+        {
+          id = "flutter-tools-copy-profiler-url",
+          label = "Flutter tools: Copy Profiler Url",
+          hint = "Run the app and the DevTools first",
+          command = require("flutter-tools.commands").copy_profiler_url,
+        },
+      })
+  else
+      vim.list_extend(commands, {
+        {
+          id = "flutter-tools-start-dev-tools",
+          label = "Flutter tools: Start Dev Tools",
+          hint = "Open flutter dev tools in the browser",
+          command = require("flutter-tools.dev_tools").start,
+        },
+      })
+  end
 
   opts = opts and not vim.tbl_isempty(opts) and opts or themes.get_dropdown({
     previewer = false,


### PR DESCRIPTION
~~~This depends on #44. The way I detect whether the devtools server is running will be changed once that's merged~~

- [x] ~~Documentation~~
- [X] Hide disabled commands in telescope menu
- [x] Fix conflicts with #44 

There are 2 main conditions to group commands: **devtools server running** and **flutter run running**
### Always enabled
- `FlutterDevices`
- `FlutterEmulators`
- `FlutterOpenOutline`
- `FlutterLogClear`

### Devtools server
#### Running
- `FlutterCopyProfileUrl`
#### Not running
- `FlutterDevTools`

### Flutter run
#### Running
- `FlutterReload`
- `FlutterRestart`
- `FlutterVisualDebug`
- `FlutterQuit`

#### Not running
- `FlutterRun`

### Devtools not running, flutter not running
![image](https://user-images.githubusercontent.com/13708100/118396473-fc824700-b64f-11eb-8580-60227abe4b9f.png)

### Devtools not running, flutter running
![image](https://user-images.githubusercontent.com/13708100/118397210-40c31680-b653-11eb-8b5c-d6bb95b4d5c9.png)

### Devtools running, flutter not running
![image](https://user-images.githubusercontent.com/13708100/118396538-3e12f200-b650-11eb-8bd1-a298fcd14b3c.png)

### Devtools running, flutter running
![image](https://user-images.githubusercontent.com/13708100/118396612-8fbb7c80-b650-11eb-86fb-80fcf1283fa3.png)

