### PR TITLE
autostart devtools if not detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ require("flutter-tools").setup {
   dev_log = {
     open_cmd = "tabedit", -- command to use to open the log buffer
   },
+  dev_tools = {
+    autostart = false, -- autostart devtools server if not detected
+  },
   outline = {
     open_cmd = "30vnew", -- command to use to open the outline buffer
   },

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -53,6 +53,9 @@ local defaults = {
       return k == "open_cmd" and get_split_cmd(0.4, 50) or nil
     end,
   }),
+  dev_tools = {
+    autostart = false,
+  },
   experimental = {
     lsp_derive_paths = false,
   },

--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -55,10 +55,17 @@ function M.handle_log(data)
     return
   end
 
+  if profiler_url then
+    return
+  end
+
   profiler_url = try_get_profiler_url(data)
 
   if profiler_url then
-    ui.notify({"Profiler url detected: ", profiler_url})
+    local autostart = require("flutter-tools.config").get("dev_tools").autostart
+    if autostart then
+      M.start()
+    end
   end
 end
 


### PR DESCRIPTION
closes #48 
also fixed a bug in which the value of `profiler_url` is overriden if devtools is not started

- [x] Update documentation
- [X] Implement feature
- [X] Works on my machine (enabling/disabling the config works as expected)

A new configuration has been added. This feature is disabled by default
```
dev_tools = {
  autostart = false
}
```