### PR TITLE
feat: add commandline args for run command

### DIFF
--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -3,7 +3,11 @@ local M = {}
 local function setup_commands()
   local utils = require("flutter-tools.utils")
   -- Commands
-  utils.command("FlutterRun", [[lua require('flutter-tools.commands').run()]])
+  utils.command(
+    "FlutterRun",
+    [[lua require('flutter-tools.commands').run_command(<q-args>)]],
+    { nargs = "*" }
+  )
   utils.command("FlutterReload", [[lua require('flutter-tools.commands').reload()]])
   utils.command("FlutterRestart", [[lua require('flutter-tools.commands').restart()]])
   utils.command("FlutterQuit", [[lua require('flutter-tools.commands').quit()]])

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -92,14 +92,14 @@ end
 ---@param args string
 function M.run_command(args)
   args = vim.split(args, " ")
-  M.run({ extra = args })
+  M.run({ args = args })
 end
 
 ---Run the flutter application
 ---@param opts table
 function M.run(opts)
   local device = opts.device
-  local cmd_args = opts.extra
+  local cmd_args = opts.args
   if run_job then
     return utils.echomsg("Flutter is already running!")
   end
@@ -117,6 +117,7 @@ function M.run(opts)
     if dev_url then
       vim.list_extend(args, { "--devtools-server-address", dev_url })
     end
+
     ui.notify({ "Starting flutter project..." })
     local conf = config.get("dev_log")
     run_job = Job:new({

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -87,14 +87,30 @@ local function shutdown()
   dev_tools.on_flutter_shutdown()
 end
 
-function M.run(device)
+--- Take arguments from the commandline and pass
+--- them to the run command
+---@param args string
+function M.run_command(args)
+  args = vim.split(args, " ")
+  M.run({ extra = args })
+end
+
+---Run the flutter application
+---@param opts table
+function M.run(opts)
+  local device = opts.device
+  local cmd_args = opts.args
   if run_job then
     return utils.echomsg("Flutter is already running!")
   end
   executable.flutter(function(cmd)
     local args = { "run" }
-    if device and device.id then
+    if not cmd_args and device and device.id then
       vim.list_extend(args, { "-d", device.id })
+    end
+
+    if cmd_args then
+      vim.list_extend(args, cmd_args)
     end
 
     local dev_url = dev_tools.get_url()

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -91,7 +91,7 @@ end
 --- them to the run command
 ---@param args string
 function M.run_command(args)
-  args = vim.split(args, " ")
+  args = args and args ~= "" and vim.split(args, " ") or nil
   M.run({ args = args })
 end
 

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -99,7 +99,7 @@ end
 ---@param opts table
 function M.run(opts)
   local device = opts.device
-  local cmd_args = opts.args
+  local cmd_args = opts.extra
   if run_job then
     return utils.echomsg("Flutter is already running!")
   end

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -116,7 +116,7 @@ function _G.__flutter_tools_select_device()
     if device.type == EMULATOR then
       M.launch_emulator(device)
     else
-      require("flutter-tools.commands").run(device)
+      require("flutter-tools.commands").run({ device = device })
     end
     api.nvim_win_close(0, true)
   end

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 local fn = vim.fn
 local api = vim.api
+local fmt = string.format
 
 function M.echomsg(msg, hl)
   hl = hl or "Title"
@@ -32,8 +33,14 @@ function M.display_name(name, platform)
     .. (platform and platform ~= "" and (" " .. symbol .. " ") .. platform or "")
 end
 
-function M.command(name, rhs)
-  vim.cmd("command! " .. name .. " " .. rhs)
+---Create a neovim command
+---@param name string
+---@param rhs string
+---@param modifiers string[]
+function M.command(name, rhs, modifiers)
+  modifiers = modifiers or {}
+  local nargs = modifiers and modifiers.nargs or 0
+  vim.cmd(fmt("command! -nargs=%s %s %s", nargs, name, rhs))
 end
 
 --- if every item in a table is an empty value return true


### PR DESCRIPTION
Add the ability to allow passing commands to flutter run. This is done by taking args via the command line command e.g.
`FlutterRun --flavor dev`
`FlutterRun --no-sound-null-safety`

This means this can also be mapped for reuse e.g.
`nnoremap ,frd <Cmd>FlutterRun --flavor dev`

fixes #70 