### PR TITLE
fix(telescope): guard against nil opts in Run command from telescope

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -98,6 +98,7 @@ end
 ---Run the flutter application
 ---@param opts table
 function M.run(opts)
+  opts = opts or {}
   local device = opts.device
   local cmd_args = opts.args
   if run_job then


### PR DESCRIPTION
This PR fixes bug: `attempt to index local 'opts' (a nil value)` when executing Run command in Telescope, 