### PR TITLE
refactor: add compat helper for lsp handlers

### DIFF
--- a/lua/flutter-tools/guides.lua
+++ b/lua/flutter-tools/guides.lua
@@ -183,7 +183,7 @@ local function is_buf_valid(bufnum)
     and vim.bo.buftype == ""
 end
 
-function M.widget_guides(_, _, data, _)
+function M.widget_guides(_, data, _, _)
   local conf = config.get().widget_guides
   if conf.enabled then
     local bufnum = vim.uri_to_bufnr(data.uri)

--- a/lua/flutter-tools/labels.lua
+++ b/lua/flutter-tools/labels.lua
@@ -19,7 +19,7 @@ local function render_labels(labels, opts)
 end
 
 --- returns a function which handles rendering floating labels
-function M.closing_tags(err, _, response)
+function M.closing_tags(err, response, _)
   local conf = require("flutter-tools.config").get()
   local opts = conf.closing_tags
   if err or not opts.enabled then

--- a/lua/flutter-tools/lsp/code_actions.lua
+++ b/lua/flutter-tools/lsp/code_actions.lua
@@ -24,6 +24,7 @@ end
 ---@param on_complete function
 function M.execute(action, bufnr, on_complete)
   bufnr = bufnr or 0
+  on_complete = on_complete and require("flutter-tools.utils").lsp_handler(on_complete) or nil
   -- textDocument/codeAction can return either Command[] or CodeAction[].
   -- If it is a CodeAction, it can have either an edit, a command or both.
   -- Edits should be executed first

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -65,9 +65,15 @@ local function get_defaults(opts)
       },
     },
     handlers = {
-      ["dart/textDocument/publishClosingLabels"] = require("flutter-tools.labels").closing_tags,
-      ["dart/textDocument/publishOutline"] = require("flutter-tools.outline").document_outline,
-      ["dart/textDocument/publishFlutterOutline"] = require("flutter-tools.guides").widget_guides,
+      ["dart/textDocument/publishClosingLabels"] = utils.lsp_handler(
+        require("flutter-tools.labels").closing_tags
+      ),
+      ["dart/textDocument/publishOutline"] = utils.lsp_handler(
+        require("flutter-tools.outline").document_outline
+      ),
+      ["dart/textDocument/publishFlutterOutline"] = utils.lsp_handler(
+        require("flutter-tools.guides").widget_guides
+      ),
     },
     capabilities = (function()
       local capabilities = lsp.protocol.make_client_capabilities()

--- a/lua/flutter-tools/outline.lua
+++ b/lua/flutter-tools/outline.lua
@@ -385,17 +385,22 @@ local function request_code_actions()
   local code_win = find_code_window(uri)
   local outline_win = api.nvim_get_current_win()
 
-  lsp.buf_request(params.bufnr, "textDocument/codeAction", params, function(_, _, actions)
-    code_actions.create_popup(actions, function(buf, win)
-      utils.map(
-        "n",
-        "<CR>",
-        select_code_action(actions, win, code_buf, code_win, outline_win),
-        { buffer = buf }
-      )
+  lsp.buf_request(
+    params.bufnr,
+    "textDocument/codeAction",
+    params,
+    utils.lsp_handler(function(_, actions, _)
+      code_actions.create_popup(actions, function(buf, win)
+        utils.map(
+          "n",
+          "<CR>",
+          select_code_action(actions, win, code_buf, code_win, outline_win),
+          { buffer = buf }
+        )
+      end)
+      vim.api.nvim_win_set_cursor(code_win, { item.start_line + 1, item.start_col + 1 })
     end)
-    vim.api.nvim_win_set_cursor(code_win, { item.start_line + 1, item.start_col + 1 })
-  end)
+  )
 end
 
 local function select_outline_item()
@@ -487,7 +492,7 @@ function M.open(opts)
   end
 end
 
-function M.document_outline(_, _, data, _)
+function M.document_outline(_, data, _, _)
   local outline = data.outline or {}
   local result = {}
   if not outline.children or #outline.children == 0 then

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -214,4 +214,27 @@ function M.open_command()
   return nil, nil
 end
 
+
+---Create an lsp handler compatible with the new handler signature
+---@see: https://github.com/neovim/neovim/pull/15504/
+---@param func function
+---@return function
+function M.lsp_handler(func)
+  return function(...)
+    local config_or_client_id = select(4, ...)
+    local is_new = type(config_or_client_id) ~= "number"
+    if is_new then
+      func(...)
+    else
+      local err = select(1, ...)
+      local method = select(2, ...)
+      local result = select(3, ...)
+      local client_id = select(4, ...)
+      local bufnr = select(5, ...)
+      local config = select(6, ...)
+      func(err, result, { method = method, client_id = client_id, bufnr = bufnr }, config)
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
This updates lsp handlers to use the new function signatures and handles
older versions of neovim which do not yet have this.

Relates to https://github.com/neovim/neovim/pull/15504