### PR TITLE
feat: Execute flutter commands in lsp project root

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -6,6 +6,7 @@ local config = require("flutter-tools.config")
 local executable = require("flutter-tools.executable")
 local dev_log = require("flutter-tools.log")
 local dev_tools = require("flutter-tools.dev_tools")
+local lsp = require("flutter-tools.lsp")
 
 local api = vim.api
 
@@ -127,6 +128,7 @@ function M.run(opts)
     run_job = Job:new({
       command = cmd,
       args = args,
+      cwd = lsp.get_lsp_root_dir(),
       on_start = function()
         vim.cmd("doautocmd User FlutterToolsAppStarted")
       end,
@@ -219,7 +221,11 @@ local pub_get_job = nil
 function M.pub_get()
   if not pub_get_job then
     executable.flutter(function(cmd)
-      pub_get_job = Job:new({ command = cmd, args = { "pub", "get" } })
+      pub_get_job = Job:new({
+        command = cmd,
+        args = { "pub", "get" },
+        cwd = lsp.get_lsp_root_dir(),
+      })
       pub_get_job:after_success(vim.schedule_wrap(function(j)
         on_pub_get(j:result())
         pub_get_job = nil
@@ -252,7 +258,7 @@ function M.pub_upgrade(cmd_args)
       if cmd_args then
         vim.list_extend(args, cmd_args)
       end
-      pub_upgrade_job = Job:new({ command = cmd, args = args })
+      pub_upgrade_job = Job:new({ command = cmd, args = args, cwd = lsp.get_lsp_root_dir() })
       pub_upgrade_job:after_success(vim.schedule_wrap(function(j)
         ui.notify(j:result(), notify_timeout)
         pub_upgrade_job = nil

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -174,4 +174,17 @@ function M.attach()
   end)
 end
 
+function M.get_lsp_root_dir()
+  for _, buf in pairs(vim.fn.getbufinfo({ bufloaded = true })) do
+    if api.nvim_buf_get_option(buf.bufnr, "filetype") == FILETYPE then
+      local clients = lsp.buf_get_clients(buf.bufnr)
+      for _, client in ipairs(clients) do
+        if client.config.name == SERVER_NAME then
+          return client.config.root_dir
+        end
+      end
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
Hello, 

Currently `flutter run` and `flutter pub get/upgrade` commands are run in neovim `cwd` directory by default.
In my project, the flutter project in a subdir in the monorepo, which means these command fail.

I couldn´t think of any reason not to use the dartls server root_dir config (which is correctly computed by the plugin) as the `cwd` for these commands.

I'm fairly new to neovim so that may be an oversight on my part, please let me know.

Thank you.