### PR TITLE
fix: callback name for plenary job execution

### DIFF
--- a/lua/flutter-tools/runners/job_runner.lua
+++ b/lua/flutter-tools/runners/job_runner.lua
@@ -31,7 +31,7 @@ function JobRunner:run(paths, args, cwd, on_run_data, on_run_exit)
       on_run_data(false, data)
       dev_tools.handle_log(data)
     end),
-    on_sterr = vim.schedule_wrap(function(_, data, _)
+    on_stderr = vim.schedule_wrap(function(_, data, _)
       on_run_data(true, data)
     end),
     on_exit = vim.schedule_wrap(function(j, _)


### PR DESCRIPTION
This pull request fix the name of callback for plenary job. The incorrect name is causing errors like this issue: [#112](https://github.com/akinsho/flutter-tools.nvim/issues/112)