### PR TITLE
fix: allow flutter run to take cli arguments

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -102,11 +102,9 @@ local function on_run_exit(result, cli_args)
       highlights = highlights,
       on_create = function(buf, _)
         vim.b.devices = win_devices
-        utils.map("n", "<CR>",
-        function()
+        utils.map("n", "<CR>", function()
           devices.select_device(cli_args)
-        end,
-          { buffer = buf })
+        end, { buffer = buf })
       end,
     })
   end

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -92,7 +92,7 @@ end
 
 ---Handle a finished flutter run command
 ---@param result string[]
-local function on_run_exit(result, original_args)
+local function on_run_exit(result, cli_args)
   local matched_error, msg = has_recoverable_error(result)
   if matched_error then
     local lines, win_devices, highlights = devices.extract_device_props(result)
@@ -104,7 +104,7 @@ local function on_run_exit(result, original_args)
         vim.b.devices = win_devices
         utils.map("n", "<CR>",
         function()
-          devices.select_device(original_args)
+          devices.select_device(cli_args)
         end,
           { buffer = buf })
       end,
@@ -130,10 +130,10 @@ function M.run(opts)
   opts = opts or {}
   local device = opts.device
   local cmd_args = opts.args
-  local full_args = opts.full_args
+  local cli_args = opts.cli_args
   executable.get(function(paths)
-    local args = full_args or {}
-    if not full_args then
+    local args = cli_args or {}
+    if not cli_args then
       if not M.use_dap_runner() then
         vim.list_extend(args, { "run" })
       end

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -92,7 +92,7 @@ end
 
 ---Handle a finished flutter run command
 ---@param result string[]
-local function on_run_exit(result)
+local function on_run_exit(result, original_args)
   local matched_error, msg = has_recoverable_error(result)
   if matched_error then
     local lines, win_devices, highlights = devices.extract_device_props(result)
@@ -102,7 +102,11 @@ local function on_run_exit(result)
       highlights = highlights,
       on_create = function(buf, _)
         vim.b.devices = win_devices
-        utils.map("n", "<CR>", devices.select_device, { buffer = buf })
+        utils.map("n", "<CR>",
+        function()
+          devices.select_device(original_args)
+        end,
+          { buffer = buf })
       end,
     })
   end
@@ -126,22 +130,25 @@ function M.run(opts)
   opts = opts or {}
   local device = opts.device
   local cmd_args = opts.args
+  local full_args = opts.full_args
   executable.get(function(paths)
-    local args = {}
-    if not M.use_dap_runner() then
-      vim.list_extend(args, { "run" })
-    end
-    if not cmd_args and device and device.id then
-      vim.list_extend(args, { "-d", device.id })
-    end
+    local args = full_args or {}
+    if not full_args then
+      if not M.use_dap_runner() then
+        vim.list_extend(args, { "run" })
+      end
+      if not cmd_args and device and device.id then
+        vim.list_extend(args, { "-d", device.id })
+      end
 
-    if cmd_args then
-      vim.list_extend(args, cmd_args)
-    end
+      if cmd_args then
+        vim.list_extend(args, cmd_args)
+      end
 
-    local dev_url = dev_tools.get_url()
-    if dev_url then
-      vim.list_extend(args, { "--devtools-server-address", dev_url })
+      local dev_url = dev_tools.get_url()
+      if dev_url then
+        vim.list_extend(args, { "--devtools-server-address", dev_url })
+      end
     end
     ui.notify({ "Starting flutter project..." })
     runner = M.use_dap_runner() and dap_runner or job_runner

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -89,7 +89,7 @@ function M.extract_device_props(result, device_type)
   return lines, devices_by_line, highlights
 end
 
-function M.select_device()
+function M.select_device(args)
   if not vim.b.devices then
     return utils.notify("Sorry there is no device on this line")
   end
@@ -100,7 +100,12 @@ function M.select_device()
     if device.type == EMULATOR then
       M.launch_emulator(device)
     else
-      require("flutter-tools.commands").run({ device = device })
+      if args then
+        vim.list_extend(args, { "-d", device.id })
+        require("flutter-tools.commands").run({ full_args = args })
+      else
+        require("flutter-tools.commands").run({ device = device })
+      end
     end
     api.nvim_win_close(0, true)
   end

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -102,7 +102,7 @@ function M.select_device(args)
     else
       if args then
         vim.list_extend(args, { "-d", device.id })
-        require("flutter-tools.commands").run({ full_args = args })
+        require("flutter-tools.commands").run({ cli_args = args })
       else
         require("flutter-tools.commands").run({ device = device })
       end

--- a/lua/flutter-tools/runners/dap_runner.lua
+++ b/lua/flutter-tools/runners/dap_runner.lua
@@ -43,7 +43,7 @@ function DAPRunner:run(paths, args, cwd, on_run_data, on_run_exit)
 
   local handle_termination = function()
     if next(before_start_logs) ~= nil then
-      on_run_exit(before_start_logs)
+      on_run_exit(before_start_logs, args)
     end
   end
 

--- a/lua/flutter-tools/runners/job_runner.lua
+++ b/lua/flutter-tools/runners/job_runner.lua
@@ -36,7 +36,7 @@ function JobRunner:run(paths, args, cwd, on_run_data, on_run_exit)
       on_run_data(true, data)
     end),
     on_exit = vim.schedule_wrap(function(j, _)
-      on_run_exit(j:result())
+      on_run_exit(j:result(), args)
     end),
   })
   run_job:start()


### PR DESCRIPTION
#118 

Fix flutter run not using arguments.

This wont work for emulators, I think I can get it to work by just extending the args again and then using the run method instead of emulator run, but im not sure if that might break something else.