### PR TITLE
feat: add dev log toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ require("flutter-tools").setup{} -- use defaults
 - `FlutterCopyProfilerUrl` - Copies the profiler url to your system clipboard (+ register). Note that commands `FlutterRun` and
   `FlutterDevTools` must be executed first.
 - `FlutterLspRestart` - This command restarts the dart language server, and is intended for situations where it begins to work incorrectly.
+- `FlutterLogToggle` - This command toggles the logging output window.
 
 <hr/>
 

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -34,6 +34,7 @@ local function setup_commands()
   )
   --- Log
   utils.command("FlutterLogClear", [[lua require('flutter-tools.log').clear()]])
+  utils.command("FlutterLogToggle", [[lua require('flutter-tools.log').toggle()]])
 end
 
 ---Initialise various plugin modules

--- a/lua/flutter-tools/log.lua
+++ b/lua/flutter-tools/log.lua
@@ -1,3 +1,4 @@
+local config = require("flutter-tools.config")
 local ui = require("flutter-tools.ui")
 local utils = require("flutter-tools.utils")
 
@@ -28,11 +29,11 @@ local function close_dev_log()
   M.win = nil
 end
 
-local function create(config)
+local function create(conf)
   local opts = {
     filename = M.filename,
     filetype = "log",
-    open_cmd = config.open_cmd,
+    open_cmd = conf.open_cmd,
   }
   ui.open_win(opts, function(buf, win)
     if not buf then
@@ -114,6 +115,17 @@ function M.clear()
     vim.bo[M.buf].modifiable = true
     api.nvim_buf_set_lines(M.buf, 0, -1, false, {})
     vim.bo[M.buf].modifiable = false
+  end
+end
+
+function M.toggle()
+  if M.win then
+    api.nvim_win_close(M.win, true)
+    M.win = nil
+  elseif exists() then
+    pcall(function()
+      create(config.get("dev_log"))
+    end)
   end
 end
 


### PR DESCRIPTION
> @rlch the reason I don't want to really entertain the idea of "toggling" the dev log is that it can be opened in any possible way that nvim allows opening a buffer so the whole idea of toggling is quite complex since you might be toggling a tab or a split or it might replace the current window, which means it's quite hard to know what is being opened or closed. I did look into this at some point last year and it proved to be quite complex to try and cover all these cases. The above command would work if you opened a split but not if you opened this buffer using a tab.

I have only accounted for the dev log buffer being opened as a split. Creating this PR as a small foundation to build off to properly implement this feature. 

closes #84 