### PR TITLE
feat: add handler for textDocument/documentColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ require("flutter-tools").setup{} -- use defaults
 
 ![flutter-devices](https://user-images.githubusercontent.com/22454918/112320203-b5f31a80-8ca6-11eb-90b8-9ac934a842da.png)
 
+#### Visualise colours from LSP
+
+![lsp-colours](https://user-images.githubusercontent.com/22454918/153088850-a14f9e67-4d28-47ad-a768-c6c318524951.png)
+
 #### Visualise logs
 
 ![dev log](./.github/dev_log.png)
@@ -221,6 +225,12 @@ require("flutter-tools").setup {
     auto_open = false -- if true this will open the outline automatically when it is first populated
   },
   lsp = {
+    color = { -- show the derived colours for dart variables
+      background = false, -- highlight the background
+      foreground = false, -- highlight the foreground
+      virtual_text = true, -- show the highlight using virtual text
+      virtual_text_str = "■", -- the virtual text character to highlight
+    },
     on_attach = my_custom_on_attach,
     capabilities = my_custom_capabilities -- e.g. lsp_status capabilities
     --- OR you can specify a function to deactivate or change or control how the config is created

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -95,7 +95,9 @@ local function setup_autocommands()
       end,
     },
     {
-      events = { "User FlutterToolsLspInitialized" },
+      -- NOTE: we piggyback of this event to check for when the server is first initialized
+      events = { "User FlutterToolsLspAnalysisComplete" },
+      modifiers = { "++once" },
       command = function()
         require("flutter-tools.lsp").document_color()
       end,

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -94,6 +94,12 @@ local function setup_autocommands()
         require("flutter-tools.lsp").document_color()
       end,
     },
+    {
+      events = { "User FlutterToolsLspInitialized" },
+      command = function()
+        require("flutter-tools.lsp").document_color()
+      end,
+    },
   })
 
   utils.augroup("FlutterToolsHotReload", {

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -88,7 +88,7 @@ local function setup_autocommands()
 
   utils.augroup("FlutterToolsLspColors", {
     {
-      events = { "TextChanged", "InsertLeave" },
+      events = { "BufEnter", "TextChanged", "InsertLeave" },
       targets = { "*.dart" },
       command = function()
         require("flutter-tools.lsp").document_color()

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -86,6 +86,16 @@ local function setup_autocommands()
     },
   })
 
+  utils.augroup("FlutterToolsLspColors", {
+    {
+      events = { "TextChanged", "InsertLeave" },
+      targets = { "*.dart" },
+      command = function()
+        require("flutter-tools.lsp").document_color()
+      end,
+    },
+  })
+
   utils.augroup("FlutterToolsHotReload", {
     {
       events = { "BufWritePost" },

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -2,6 +2,7 @@ local path = require("flutter-tools.utils.path")
 local M = {}
 
 local fn = vim.fn
+local api = vim.api
 local fmt = string.format
 
 --- @param prefs table user preferences
@@ -90,6 +91,20 @@ local defaults = {
   },
   lsp = {
     debug = M.debug_levels.WARN,
+    color = setmetatable({
+      background = true,
+      foreground = false,
+      virtual_text = false,
+      virtual_text_str = "■",
+    }, {
+      __index = function(_, k)
+        if k == "background_color" then
+          return require("flutter-tools.lsp.color.utils").decode_24bit_rgb(
+            api.nvim_get_hl_by_name("Normal", true)["background"]
+          )
+        end
+      end,
+    }),
   },
   outline = setmetatable({
     auto_open = false,

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -41,7 +41,7 @@ M.debug_levels = {
   WARN = 2,
 }
 
-local defaults = {
+local config = {
   flutter_path = nil,
   flutter_lookup_cmd = get_default_lookup(),
   fvm = false,
@@ -91,20 +91,15 @@ local defaults = {
   },
   lsp = {
     debug = M.debug_levels.WARN,
-    color = setmetatable({
-      background = true,
+    color = {
+      background = false,
       foreground = false,
-      virtual_text = false,
+      virtual_text = true,
       virtual_text_str = "■",
-    }, {
-      __index = function(_, k)
-        if k == "background_color" then
-          return require("flutter-tools.lsp.color.utils").decode_24bit_rgb(
-            api.nvim_get_hl_by_name("Normal", true)["background"]
-          )
-        end
-      end,
-    }),
+      background_color = require("flutter-tools.lsp.color.utils").decode_24bit_rgb(
+        api.nvim_get_hl_by_name("Normal", true)["background"]
+      ),
+    },
   },
   outline = setmetatable({
     auto_open = false,
@@ -133,7 +128,7 @@ local deprecations = {
   },
 }
 
-local function handle_deprecation(key, value, config)
+local function handle_deprecation(key, value, conf)
   local utils = require("flutter-tools.utils")
   local deprecation = deprecations[key]
   if not deprecation then
@@ -143,11 +138,9 @@ local function handle_deprecation(key, value, config)
     utils.notify(fmt("%s is deprecated: %s", key, deprecation.message), utils.L.WARN)
   end, 1000)
   if deprecation.fallback then
-    config[deprecation.fallback] = value
+    conf[deprecation.fallback] = value
   end
 end
-
-local config = setmetatable({}, { __index = defaults })
 
 ---Get the configuration or just a key of the config
 ---@param key string
@@ -166,11 +159,8 @@ function M.set(user_config)
   validate_prefs(user_config)
   for key, value in pairs(user_config) do
     handle_deprecation(key, value, user_config)
-    if user_config[key] and type(user_config[key]) == "table" then
-      setmetatable(user_config[key], { __index = defaults[key] })
-    end
   end
-  config = setmetatable(user_config, { __index = defaults })
+  config = vim.tbl_deep_extend("keep", user_config, config)
   return config
 end
 

--- a/lua/flutter-tools/lsp/color/init.lua
+++ b/lua/flutter-tools/lsp/color/init.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.document_color()
+  local params = {
+    textDocument = vim.lsp.util.make_text_document_params(),
+  }
+  vim.lsp.buf_request(0, "textDocument/documentColor", params)
+end
+
+M.on_document_color = require("flutter-tools.lsp.color.utils").on_document_color
+
+return M

--- a/lua/flutter-tools/lsp/color/utils.lua
+++ b/lua/flutter-tools/lsp/color/utils.lua
@@ -1,0 +1,233 @@
+local tohex, bor, lshift, rshift, band = bit.tohex, bit.bor, bit.lshift, bit.rshift, bit.band
+local validate, api = vim.validate, vim.api
+
+local M = {}
+
+--- Returns a table containing the RGB values produced by applying the alpha in
+--- @rgba with the background in @bg_rgb.
+---
+--@param rgba (table) with keys 'r', 'g', 'b' in [0,255] and key 'a' in [0,1]
+--@param bg_rgb (table) with keys 'r', 'g', 'b' in in [0,255] to use as the
+--       background color when applying the alpha
+--@returns (table) with keys 'r', 'g', 'b' in [0,255]
+function M.rgba_to_rgb(rgba, bg_rgb)
+  validate({
+    rgba = { rgba, "t", true },
+    bg_rgb = { bg_rgb, "t", false },
+    r = { rgba.r, "n", true },
+    g = { rgba.g, "n", true },
+    b = { rgba.b, "n", true },
+    a = { rgba.a, "n", true },
+  })
+
+  bg_rgb = bg_rgb or M.decode_24bit_rgb(api.nvim_get_hl_by_name("Normal", true)["background"])
+  validate({
+    bg_r = { bg_rgb.r, "n", true },
+    bg_g = { bg_rgb.g, "n", true },
+    bg_b = { bg_rgb.b, "n", true },
+  })
+
+  local r = rgba.r * rgba.a + bg_rgb.r * (1 - rgba.a)
+  local g = rgba.g * rgba.a + bg_rgb.g * (1 - rgba.a)
+  local b = rgba.b * rgba.a + bg_rgb.b * (1 - rgba.a)
+
+  return { r = r, g = g, b = b }
+end
+
+--- Returns a string containing the 6 digit hex value for a given RGB.
+---
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+--@returns (string) 6 digit hex representing the rgb params
+function M.rgb_to_hex(rgb)
+  validate({
+    r = { rgb.r, "n", false },
+    g = { rgb.g, "n", false },
+    b = { rgb.b, "n", false },
+  })
+  return tohex(bor(lshift(rgb.r, 16), lshift(rgb.g, 8), rgb.b), 6)
+end
+
+--- Returns a string containing the 6 digit hex value produced by applying the alpha in
+--- the @rgba with the background @bg_rgb.
+---
+--@param rgba (table) with keys 'r', 'g', 'b' in [0,255] and key 'a' in [0,1]
+--@returns (string) 6 digit hex
+function M.rgba_to_hex(rgba, bg_rgb)
+  return M.rgb_to_hex(M.rgba_to_rgb(rgba, bg_rgb))
+end
+
+--- Returns a table containing the RGB values encoded inside 24 least
+--- significant bits of the number @rgb_24bit
+---
+--@param rgb_24bit (number) 24-bit RGB value
+--@returns (table) with keys 'r', 'g', 'b' in [0,255]
+function M.decode_24bit_rgb(rgb_24bit)
+  validate({ rgb_24bit = { rgb_24bit, "n", true } })
+  local r = band(rshift(rgb_24bit, 16), 255)
+  local g = band(rshift(rgb_24bit, 8), 255)
+  local b = band(rgb_24bit, 255)
+  return { r = r, g = g, b = b }
+end
+
+--- Returns the perceived lightness of the rgb value. Calculated using
+--- the formula from https://stackoverflow.com/a/56678483. Can be used to
+--- determine which colors have similar lightness.
+---
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+--@returns (number) lightness in the range [0,100]
+function M.perceived_lightness(rgb)
+  local function gamma_encode(v)
+    return v / 255
+  end
+  local function linearize(v)
+    return v <= 0.04045 and v / 12.92 or math.pow((v + 0.055) / 1.055, 2.4)
+  end
+
+  -- convert from sRGB to linear values
+  local r = linearize(gamma_encode(rgb.r))
+  local g = linearize(gamma_encode(rgb.g))
+  local b = linearize(gamma_encode(rgb.b))
+
+  -- calculate luminance
+  local L = 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+  -- calculate Y* (perceived lightness) from luminance
+  return L <= (216 / 24389) and L * (24389 / 27) or math.pow(L, 1 / 3) * 116 - 16
+end
+
+local CLIENT_NS = api.nvim_create_namespace("flutter_tools_lsp_document_color")
+
+--- Changes the guibg to @rgb for the text in @range. Also changes the guifg to
+--- either #ffffff or #000000 based on which makes the text easier to read for
+--- the given guibg
+---
+--@param client_id number client id
+--@param bufnr (number) buffer handle
+--@param range (table) with the structure:
+--       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+local function color_background(_, bufnr, range, rgb)
+  local hex = M.rgb_to_hex(rgb)
+  local fghex = M.perceived_lightness(rgb) < 50 and "ffffff" or "000000"
+
+  local hlname = string.format("LspDocumentColorBackground%s", hex)
+  api.nvim_command(string.format("highlight %s guibg=#%s guifg=#%s", hlname, hex, fghex))
+
+  local start_pos = { range["start"]["line"], range["start"]["character"] }
+  local end_pos = { range["end"]["line"], range["end"]["character"] }
+  vim.highlight.range(bufnr, CLIENT_NS, hlname, start_pos, end_pos)
+end
+
+--- Changes the guifg to @rgb for the text in @range.
+---
+--@param client_id number client id
+--@param bufnr (number) buffer handle
+--@param range (table) with the structure:
+--       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+local function color_foreground(_, bufnr, range, rgb)
+  local hex = M.rgb_to_hex(rgb)
+
+  local hlname = string.format("LspDocumentColorForeground%s", hex)
+  api.nvim_command(string.format("highlight %s guifg=#%s", hlname, hex))
+
+  local start_pos = { range["start"]["line"], range["start"]["character"] }
+  local end_pos = { range["end"]["line"], range["end"]["character"] }
+  vim.highlight.range(bufnr, CLIENT_NS, hlname, start_pos, end_pos)
+end
+
+--- Adds virtual text with the color @rgb and the text @virtual_text_str on
+--- the last line of the @range.
+---
+--@param client_id number client id
+--@param bufnr (number) buffer handle
+--@param range (table) with the structure:
+--       {start={line=<number>,character=<number>}, end={line=<number>,character=<number>}}
+--@param rgb (table) with keys 'r', 'g', 'b' in [0,255]
+--@param virtual_text_str (string) to display as virtual text and color
+local function color_virtual_text(_, bufnr, range, rgb, virtual_text_str)
+  local hex = M.rgb_to_hex(rgb)
+
+  local hlname = string.format("LspDocumentColorVirtualText%s", hex)
+  api.nvim_command(string.format("highlight %s guifg=#%s", hlname, hex))
+
+  local line = range["end"]["line"]
+  api.nvim_buf_set_virtual_text(bufnr, CLIENT_NS, line, { { virtual_text_str, hlname } }, {})
+end
+
+--- Clears the previous document colors and adds the new document colors from @result.
+--- Follows the same signature as :h lsp-handler
+function M.on_document_color(err, result, ctx, config)
+  local client_id = ctx.client_id
+  local bufnr = ctx.bufnr
+  if err then
+    return require('flutter-tools.utils').notify(err)
+  end
+  if not bufnr or not client_id then
+    return
+  end
+  M.buf_clear_color(client_id, bufnr)
+  if not result then
+    return
+  end
+  M.buf_color(client_id, bufnr, result, config)
+end
+
+--- Shows a list of document colors for a certain buffer.
+---
+--@param client_id number client id
+--@param bufnr buffer id
+--@param color_infos Table of `ColorInformation` objects to highlight.
+--       See https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor
+function M.buf_color(client_id, bufnr, color_infos, _)
+  validate({
+    bufnr = { bufnr, "n", false },
+    color_infos = { color_infos, "t", false },
+    -- config = { config, "t", true },
+  })
+  if not color_infos or not bufnr then
+    return
+  end
+
+  local config = {
+    background = true,
+    foreground = false,
+    virtual_text = false,
+    virtual_text_str = "■",
+    background_color = M.decode_24bit_rgb(
+      vim.api.nvim_get_hl_by_name("Normal", true)["background"]
+    ),
+  }
+
+  for _, color_info in ipairs(color_infos) do
+    local rgba, range = color_info.color, color_info.range
+    local r, g, b, a = rgba.red * 255, rgba.green * 255, rgba.blue * 255, rgba.alpha
+    local rgb = M.rgba_to_rgb({ r = r, g = g, b = b, a = a }, config.background_color)
+
+    if config.background then
+      color_background(client_id, bufnr, range, rgb)
+    end
+
+    if config.foreground then
+      color_foreground(client_id, bufnr, range, rgb)
+    end
+
+    if config.virtual_text then
+      color_virtual_text(client_id, bufnr, range, rgb, config.virtual_text_str)
+    end
+  end
+end
+
+--- Removes document color highlights from a buffer.
+---
+--@param client_id number client id
+--@param bufnr buffer id
+function M.buf_clear_color(client_id, bufnr)
+  validate({
+    client_id = { client_id, "n", true },
+    bufnr = { bufnr, "n", true },
+  })
+  api.nvim_buf_clear_namespace(bufnr, CLIENT_NS, 0, -1)
+end
+
+return M

--- a/lua/flutter-tools/lsp/color/utils.lua
+++ b/lua/flutter-tools/lsp/color/utils.lua
@@ -218,7 +218,9 @@ function M.buf_clear_color(client_id, bufnr)
     client_id = { client_id, "n", true },
     bufnr = { bufnr, "n", true },
   })
-  api.nvim_buf_clear_namespace(bufnr, CLIENT_NS, 0, -1)
+  if api.nvim_buf_is_valid(bufnr) then
+    api.nvim_buf_clear_namespace(bufnr, CLIENT_NS, 0, -1)
+  end
 end
 
 return M

--- a/lua/flutter-tools/lsp/color/utils.lua
+++ b/lua/flutter-tools/lsp/color/utils.lua
@@ -111,7 +111,7 @@ local function color_background(_, bufnr, range, rgb)
   local fghex = M.perceived_lightness(rgb) < 50 and "ffffff" or "000000"
 
   local hlname = string.format("LspDocumentColorBackground%s", hex)
-  api.nvim_command(string.format("highlight %s guibg=#%s guifg=#%s", hlname, hex, fghex))
+  vim.cmd(string.format("highlight %s guibg=#%s guifg=#%s", hlname, hex, fghex))
 
   local start_pos = { range["start"]["line"], range["start"]["character"] }
   local end_pos = { range["end"]["line"], range["end"]["character"] }
@@ -129,7 +129,7 @@ local function color_foreground(_, bufnr, range, rgb)
   local hex = M.rgb_to_hex(rgb)
 
   local hlname = string.format("LspDocumentColorForeground%s", hex)
-  api.nvim_command(string.format("highlight %s guifg=#%s", hlname, hex))
+  vim.cmd(string.format("highlight %s guifg=#%s", hlname, hex))
 
   local start_pos = { range["start"]["line"], range["start"]["character"] }
   local end_pos = { range["end"]["line"], range["end"]["character"] }
@@ -149,7 +149,7 @@ local function color_virtual_text(_, bufnr, range, rgb, virtual_text_str)
   local hex = M.rgb_to_hex(rgb)
 
   local hlname = string.format("LspDocumentColorVirtualText%s", hex)
-  api.nvim_command(string.format("highlight %s guifg=#%s", hlname, hex))
+  vim.cmd(string.format("highlight %s guifg=#%s", hlname, hex))
 
   local line = range["end"]["line"]
   api.nvim_buf_set_virtual_text(bufnr, CLIENT_NS, line, { { virtual_text_str, hlname } }, {})
@@ -161,7 +161,7 @@ function M.on_document_color(err, result, ctx, config)
   local client_id = ctx.client_id
   local bufnr = ctx.bufnr
   if err then
-    return require('flutter-tools.utils').notify(err)
+    return require("flutter-tools.utils").notify(err)
   end
   if not bufnr or not client_id then
     return
@@ -183,21 +183,12 @@ function M.buf_color(client_id, bufnr, color_infos, _)
   validate({
     bufnr = { bufnr, "n", false },
     color_infos = { color_infos, "t", false },
-    -- config = { config, "t", true },
   })
   if not color_infos or not bufnr then
     return
   end
 
-  local config = {
-    background = true,
-    foreground = false,
-    virtual_text = false,
-    virtual_text_str = "■",
-    background_color = M.decode_24bit_rgb(
-      vim.api.nvim_get_hl_by_name("Normal", true)["background"]
-    ),
-  }
+  local config = require("flutter-tools.config").get("lsp").color
 
   for _, color_info in ipairs(color_infos) do
     local rgba, range = color_info.color, color_info.range

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -50,8 +50,10 @@ end
 local function handle_progress(err, result, ctx)
   -- Call the existing handler for progress so plugins can also handle the event
   vim.lsp.handlers["$/progress"](err, result, ctx)
+  -- NOTE: this event gets called whenever the analysis server has completed some work
+  -- rather than just when the server has started.
   if result and result.value and result.value.kind == "end" then
-    vim.cmd("doautocmd User FlutterToolsLspInitialized")
+    vim.cmd("doautocmd User FlutterToolsLspAnalysisComplete")
   end
 end
 

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -43,6 +43,18 @@ local function create_debug_log(level)
   end
 end
 
+---Handle progress notifications from the server
+---@param err table
+---@param result table
+---@param ctx table
+local function handle_progress(err, result, ctx)
+  -- Call the existing handler for progress so plugins can also handle the event
+  vim.lsp.handlers["$/progress"](err, result, ctx)
+  if result and result.value and result.value.kind == "end" then
+    vim.cmd("doautocmd User FlutterToolsLspInitialized")
+  end
+end
+
 ---Create default config for dartls
 ---@param opts table
 ---@return table
@@ -67,6 +79,8 @@ local function get_defaults(opts)
       },
     },
     handlers = {
+      -- TODO: can this be replaced with the initialized capability
+      ["$/progress"] = handle_progress,
       ["dart/textDocument/publishClosingLabels"] = utils.lsp_handler(
         require("flutter-tools.labels").closing_tags
       ),

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -136,20 +136,14 @@ function M.get_lsp_root_dir()
 end
 
 -- FIXME: I'm not sure how to correctly wait till a server is ready before
--- sending this request so we hack this by adding a retry delay if it's too early.
--- Ideally we would wait till the server is ready.
-M.document_color = function(cancel_retry)
+-- sending this request. Ideally we would wait till the server is ready.
+M.document_color = function()
   local active_clients = vim.tbl_map(function(c)
     return c.id
   end, vim.lsp.get_active_clients())
   local dartls = get_dartls_client()
   if dartls and vim.tbl_contains(active_clients, dartls.id) then
     color.document_color()
-  elseif not cancel_retry then
-    -- HACK: The language server might not have started yet so we wait 5secs and retry this command
-    vim.defer_fn(function()
-      M.document_color(true)
-    end, 5000)
   end
 end
 M.on_document_color = color.on_document_color

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -146,7 +146,7 @@ function M.attach()
 
   debug_log("attaching LSP")
 
-  local config = utils.merge({ name = SERVER_NAME }, user_config)
+  local config = utils.merge({ name = SERVER_NAME }, user_config, {"color"})
 
   local bufnr = api.nvim_get_current_buf()
 

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -1,5 +1,6 @@
 local utils = require("flutter-tools.utils")
 local path = require("flutter-tools.utils.path")
+local color = require("flutter-tools.lsp.color")
 
 local api = vim.api
 local lsp = vim.lsp
@@ -11,6 +12,8 @@ local SERVER_NAME = "dartls"
 
 local M = {
   lsps = {},
+  document_color = color.document_color,
+  on_document_color = color.on_document_color,
 }
 
 local function analysis_server_snapshot_path(sdk_path)
@@ -75,6 +78,7 @@ local function get_defaults(opts)
       ["dart/textDocument/publishFlutterOutline"] = utils.lsp_handler(
         require("flutter-tools.guides").widget_guides
       ),
+      ["textDocument/documentColor"] = require("flutter-tools.lsp.color").on_document_color,
     },
     commands = {
       ["refactor.perform"] = require("flutter-tools.lsp.commands").refactor_perform,
@@ -83,6 +87,9 @@ local function get_defaults(opts)
       local capabilities = lsp.protocol.make_client_capabilities()
       capabilities.workspace.configuration = true
       capabilities.textDocument.completion.completionItem.snippetSupport = true
+      capabilities.textDocument.documentColor = {
+        dynamicRegistration = true,
+      }
       -- @see: https://github.com/hrsh7th/nvim-compe#how-to-use-lsp-snippet
       capabilities.textDocument.completion.completionItem.resolveSupport = {
         properties = {

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -197,7 +197,7 @@ end
 ---@param attribute string
 ---@return string
 function M.get_hl(name, attribute)
-  return fn.synIDattr(fn.hlID("Normal"), "fg")
+  return fn.synIDattr(fn.hlID(name), attribute)
 end
 
 function M.open_command()

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -167,15 +167,19 @@ end
 
 ---Merge two table but maintain metatables
 ---Priority is given to the second table
+--- FIXME: this does not copy metatables
 ---@param t1 table
 ---@param t2 table
+---@param skip string[]
 ---@return table
-function M.merge(t1, t2)
+function M.merge(t1, t2, skip)
   for k, v in pairs(t2) do
-    if (type(v) == "table") and (type(t1[k] or false) == "table") then
-      M.merge(t1[k], t2[k])
-    else
-      t1[k] = v
+    if not skip or not vim.tbl_contains(skip, k) then
+      if (type(v) == "table") and (type(t1[k] or false) == "table") then
+        M.merge(t1[k], t2[k])
+      else
+        t1[k] = v
+      end
     end
   end
   return t1


### PR DESCRIPTION
This PR adds the ability to use the colour information resolved via the LSP to show highlights for a given colour. Unlike colour plugins such as `vim-hexokinase` or `nvim-colorizer` this actually uses the correct material colours and reads colours specified in dart code. 

e.g. It correctly follows the definition of a theme variable

<img width="643" alt="Screen Shot 2022-02-08 at 22 49 08" src="https://user-images.githubusercontent.com/22454918/153088753-bbe39f7b-b458-4821-a5cd-799a02713cc2.png">

<img width="595" alt="Screen Shot 2022-02-08 at 22 49 53" src="https://user-images.githubusercontent.com/22454918/153088850-a14f9e67-4d28-47ad-a768-c6c318524951.png">

*All* the credit for this work goes to @RRethy, who worked on a PR for nvim but wasn't able to finish it
https://github.com/neovim/neovim/pull/13654

This PR essentially copy pasted his logic into this code base and plugged it in.

cc @sollymay (this is literally a basic copy and paste with very minimal testing, so could be broken)

### TODO:

- [x] Figure out how to trigger colors when the LSP has finished setting up (BufEnter is too early)
- [x] Wire up configuration options
- [x] Enable or disable by default
- [x] ??Decide on how to handle wrapped material colours (this might not need an immediate fix if at all)
- [x] Dogfood to test for bugs