### PR TITLE
chore(readme): mention of excluding pub packages on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,11 @@ you jump to the definition of `StatelessWidget`, the lsp will not try and index 
 files in that directory. If for some reason you would like this behaviour set `analysisExcludedFolders = {}`
 You cannot/should not edit the files in the sdk directly so diagnostic analysis of these file is pointless.
 
+**Exclude Note for Windows:**
+To ignore packages installed with pub, consider adding `vim.fn.expand("$HOME/AppData/Local/Pub/Cache")` to 
+`analysisExcludedFolders` if you are using PowerShell.
+
+
 #### Flutter binary
 
 In order to run flutter commands you _might_ need to pass either a _path_ or a _command_ to the plugin so it can find your


### PR DESCRIPTION
# Hi 👋

Regarding the topic discussed in https://github.com/akinsho/flutter-tools.nvim/issues/57 this fix will add another default path to prevent the LSP to load when navigating package code.

Feel free to let me know if there is another way to do the change!

## Visual example of the path

![image](https://user-images.githubusercontent.com/26344867/173431361-319b7954-dc76-4149-8d4b-cb80c5ea0b61.png)


