### PR TITLE
fix: select only dart language server when requesting color info

### DIFF
--- a/lua/flutter-tools/lsp/color/init.lua
+++ b/lua/flutter-tools/lsp/color/init.lua
@@ -5,7 +5,7 @@ function M.document_color()
     textDocument = vim.lsp.util.make_text_document_params(),
   }
 
-  local clients = vim.lsp.get_active_clients()
+  local clients = vim.lsp.get_active_clients({ name = "dartls" })
   for _, client in ipairs(clients) do
     if client.server_capabilities.colorProvider then
       client.request("textDocument/documentColor", params, nil, 0)


### PR DESCRIPTION
This fixes the error:
```
E5108: Error executing lua ...acker/start/telescope.nvim/lua/telescope/actions/set.lua:81: Vim(lua):E5108: Error executing lua ...r/neovim/HEAD-35e89bf/share/nvim/runtim
e/lua/vim/lsp.lua:1166: not found: "textDocument/documentColor" request handler for client "jsonls".                                                                     
stack traceback:                                                                                                                                                         
        [C]: in function 'error'                                                                                                                                         
        ...r/neovim/HEAD-35e89bf/share/nvim/runtime/lua/vim/lsp.lua:1166: in function 'request'                                                                          
        .../flutter-tools.nvim/lua/flutter-tools/lsp/color/init.lua:13: in function 'document_color'                                                                     
        ...er/opt/flutter-tools.nvim/lua/flutter-tools/lsp/init.lua:173: in function 'document_color'                                                                    
        ...pack/packer/opt/flutter-tools.nvim/lua/flutter-tools.lua:96: in function <...pack/packer/opt/flutter-tools.nvim/lua/flutter-tools.lua:95>                     
        .../opt/flutter-tools.nvim/lua/flutter-tools/utils/init.lua:61: in function '_execute'                                                                           
        [string ":lua"]:1: in main chunk   
```
For some reason  `jsonls`  returns  `vim.empty_dict()`  for `client.server_capabilities.colorProvider` property.