### PR TITLE
fix: attach LSP to buffer only once

### DIFF
--- a/ftplugin/dart/lsp.lua
+++ b/ftplugin/dart/lsp.lua
@@ -1,1 +1,5 @@
+if vim.b.did_ftplugin_dart_lsp then
+  return
+end
+vim.b.did_ftplugin_dart_lsp = true
 require('flutter-tools.lsp').attach()


### PR DESCRIPTION
With the new LSP attach functionality on 0.8 I stated getting `dartls` attached to the buffer several times. Looks like the problem is that `ftplugin` is called several times. 
