### PR TITLE
feat(setup): add pubspec.yaml as another start point

### DIFF
--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -80,7 +80,7 @@ local function setup_autocommands()
   -- delay plugin setup till we enter a dart file
   autocmd({ "BufEnter" }, {
     group = AUGROUP,
-    pattern = { "*.dart" },
+    pattern = { "*.dart", "pubspec.yaml" },
     once = true,
     callback = start,
   })


### PR DESCRIPTION
Without this, I need to open any dart file before :FlutterPubGet and :FlutterRun when first entering neovim with pubspec.yaml.