### PR TITLE
feat(lsp): support dart/textDocument/super method

### DIFF
--- a/ftplugin/dart/lsp.lua
+++ b/ftplugin/dart/lsp.lua
@@ -1,5 +1,1 @@
-if vim.b.did_ftplugin_dart_lsp then
-  return
-end
-vim.b.did_ftplugin_dart_lsp = true
 require('flutter-tools.lsp').attach()

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -60,6 +60,16 @@ local function setup_commands()
   cmd("FlutterLogClear", function()
     require("flutter-tools.log").clear()
   end, {})
+  --- LSP
+  local lsp = vim.lsp
+  cmd("FlutterSuper", function()
+    lsp.buf_request(
+      0,
+      "dart/textDocument/super",
+      lsp.util.make_position_params(),
+      lsp.handlers["textDocument/definition"]
+    )
+  end, {})
 end
 
 ---Initialise various plugin modules

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -80,7 +80,7 @@ local function setup_autocommands()
   -- delay plugin setup till we enter a dart file
   autocmd({ "BufEnter" }, {
     group = AUGROUP,
-    pattern = { "*.dart" },
+    pattern = { "*.dart", "pubspec.yaml" },
     once = true,
     callback = start,
   })


### PR DESCRIPTION
Add a new command `FlutterSuper` to invoke `dart/textDocument/super` to navigate to `super`.