### PR TITLE
feat: set dart comments options

### DIFF
--- a/ftplugin/dart/init.lua
+++ b/ftplugin/dart/init.lua
@@ -1,4 +1,4 @@
 require("flutter-tools.lsp").attach()
 
-vim.api.nvim_buf_set_option(0, "comments", [[sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://]])
-vim.api.nvim_buf_set_option(0, "commentstring", [[//%s]])
+vim.opt_local.comments = [[sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://]]
+vim.opt_local.commentstring = [[//%s]]

--- a/ftplugin/dart/init.lua
+++ b/ftplugin/dart/init.lua
@@ -1,0 +1,4 @@
+require("flutter-tools.lsp").attach()
+
+vim.api.nvim_buf_set_option(0, "comments", [[sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://]])
+vim.api.nvim_buf_set_option(0, "commentstring", [[//%s]])

--- a/ftplugin/dart/lsp.lua
+++ b/ftplugin/dart/lsp.lua
@@ -1,1 +1,0 @@
-require("flutter-tools.lsp").attach()


### PR DESCRIPTION
Copied same configuration as is done there: https://github.com/dart-lang/dart-vim-plugin/blob/master/ftplugin/dart.vim#L16-L18

I also renamed the file from `lsp.lua` to `init.lua`, because now it contains code unrelated to LSP.

Closes #171 
