### PR TITLE
Fixed trying to make upper on nil

### DIFF
--- a/lua/flutter-tools/ui.lua
+++ b/lua/flutter-tools/ui.lua
@@ -193,7 +193,7 @@ end
 M.notify = function(lines, opts)
   opts = opts or {}
   local timeout = opts.timeout
-  local level = vim.log.levels[opts.level:upper() or "INFO"]
+  local level = vim.log.levels[(opts.level and opts.level:upper()) or "INFO"]
   local notification_style = config.get("ui").notification_style
   if notification_style == "native" then
     vim.notify(table.concat(lines, "\n"), level, {


### PR DESCRIPTION
Hi. 
If the "opts" is empty table and level is being "nil", then ":upper()" makes exception. This should fix it