### PR TITLE
fix: do not attach LSP to buffer with diffview file URI

### DIFF
--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -10,6 +10,7 @@ local fmt = string.format
 local FILETYPE = "dart"
 local SERVER_NAME = "dartls"
 local ROOT_PATTERNS = { ".git", "pubspec.yaml" }
+local INVALID_FILE_URIS = { "diffview://" }
 
 local M = {
   lsps = {},
@@ -242,10 +243,14 @@ function M.attach()
     legacy_server_init(buf, user_config)
   else
     local fs = vim.fs
+    local bufferPath = api.nvim_buf_get_name(buf)
+    for _, invalid_uri_prefix in ipairs(INVALID_FILE_URIS) do
+      if bufferPath:find("^" .. invalid_uri_prefix) then return end
+    end
     get_server_config(user_config, function(c)
       c.root_dir = M.get_lsp_root_dir()
         or fs.dirname(fs.find(ROOT_PATTERNS, {
-          path = api.nvim_buf_get_name(buf),
+          path = bufferPath,
           upward = true,
         })[1])
       vim.lsp.start(c)

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -232,12 +232,9 @@ end
 --- Checks if buffer path is valid for attaching LSP
 local function is_valid_path(buffer_path)
   local start_index, _, uri_prefix = buffer_path:find("^(%w+://).*")
-  if start_index and uri_prefix ~= "file://" then
-    -- Do not attach LSP if file URI prefix is not file.
-    -- For example LSP will not be attached for diffview:// or fugitive:// buffers.
-    return false
-  end
-  return true
+  -- Do not attach LSP if file URI prefix is not file.
+  -- For example LSP will not be attached for diffview:// or fugitive:// buffers.
+  return not start_index or uri_prefix == "file://"
 end
 
 ---This was heavily inspired by nvim-metals implementation of the attach functionality

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -10,7 +10,7 @@ local fmt = string.format
 local FILETYPE = "dart"
 local SERVER_NAME = "dartls"
 local ROOT_PATTERNS = { ".git", "pubspec.yaml" }
-local INVALID_FILE_URIS = { "diffview://" }
+local INVALID_FILE_URIS = { "diffview://", "fugitive://" }
 
 local M = {
   lsps = {},

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -10,7 +10,6 @@ local fmt = string.format
 local FILETYPE = "dart"
 local SERVER_NAME = "dartls"
 local ROOT_PATTERNS = { ".git", "pubspec.yaml" }
-local INVALID_FILE_URIS = { "diffview://", "fugitive://" }
 
 local M = {
   lsps = {},
@@ -230,6 +229,17 @@ local function legacy_server_init(bufnr, user_config)
   end)
 end
 
+--- Checks if buffer path is valid for attaching LSP
+local function is_valid_path(buffer_path)
+  local start_index, _, uri_prefix = buffer_path:find("^(%w+://).*")
+  if start_index and uri_prefix ~= "file://" then
+    -- Do not attach LSP if file URI prefix is not file.
+    -- For example LSP will not be attached for diffview:// or fugitive:// buffers.
+    return false
+  end
+  return true
+end
+
 ---This was heavily inspired by nvim-metals implementation of the attach functionality
 function M.attach()
   local conf = require("flutter-tools.config").get()
@@ -243,14 +253,14 @@ function M.attach()
     legacy_server_init(buf, user_config)
   else
     local fs = vim.fs
-    local bufferPath = api.nvim_buf_get_name(buf)
-    for _, invalid_uri_prefix in ipairs(INVALID_FILE_URIS) do
-      if bufferPath:find("^" .. invalid_uri_prefix) then return end
-    end
+    local buffer_path = api.nvim_buf_get_name(buf)
+
+    if not is_valid_path(buffer_path) then return end
+
     get_server_config(user_config, function(c)
       c.root_dir = M.get_lsp_root_dir()
         or fs.dirname(fs.find(ROOT_PATTERNS, {
-          path = bufferPath,
+          path = buffer_path,
           upward = true,
         })[1])
       vim.lsp.start(c)


### PR DESCRIPTION
I am using [diffview](https://github.com/sindrets/diffview.nvim) plugin, but when trying to open file history I am getting 4 error messages (see screenshot below). LSP server tries to attach to history files but fails because the path starts with `diffview://`. 

The simplest solution is to ignore these buffers. That is what I did in this PR. But not sure if this is the best solution - there could be other plugins that use other file prefixes, so in that case, we need to update the plugin again. One idea was not to attach LSP if the buffer is not modifiable, but that option is added later than attach event.

(We should also fix the problem, that there are 4 error messages instead of 2 and some of them are without any message)

<img width="961" alt="image" src="https://user-images.githubusercontent.com/4973296/200941916-af81cf51-d9ab-40e6-ab68-b764347a1a1b.png">
