### PR TITLE
fix(dap): read vmServiceUri for profiler_url

### DIFF
--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -60,7 +60,7 @@ function DebuggerRunner:run(paths, args, cwd, on_run_data, on_run_exit)
   end
 
   dap.listeners.before["event_dart.debuggerUris"][plugin_identifier] = function(_, body)
-    if body and body.observatoryUri then dev_tools.register_profiler_url(body.observatoryUri) end
+    if body and body.vmServiceUri then dev_tools.register_profiler_url(body.vmServiceUri) end
   end
 
   dap.listeners.before["event_dart.serviceExtensionAdded"][plugin_identifier] = function(_, body)
@@ -70,11 +70,11 @@ function DebuggerRunner:run(paths, args, cwd, on_run_data, on_run_exit)
   end
 
   dap.listeners.before["event_flutter.serviceExtensionStateChanged"][plugin_identifier] =
-    function(_, body)
-      if body and body.extension and body.value then
-        service_extensions_state[body.extension] = body.value
-      end
+  function(_, body)
+    if body and body.extension and body.value then
+      service_extensions_state[body.extension] = body.value
     end
+  end
 
   local launch_configurations = {}
   local launch_configuration_count = 0


### PR DESCRIPTION
Currently, when running via dap, the plugin is not able to detect the profiler_url.

While running with dap debugger, the plugin currently tries to set the profiler_url by trying to read `observatoryUri` from the body of 'event_dart.debuggerUris'.

But, the field `observatoryUri` is not available. The body instead has the field `vmServiceUri` with the websocket uri for the vm service. With this change, the plugin is now able to detect the profiler url and users can run the `FlutterCopyProfilerUrl` command to copy the devtools url
