### PR TITLE
fix(devtools): use new dart devtools command

### DIFF
--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -139,17 +139,12 @@ end
 function M.start()
   if can_start() then
     ui.notify({ "Starting dev tools..." })
-    executable.flutter(function(cmd)
+    executable.dart(function(cmd)
       job = Job:new({
         command = cmd,
         args = {
-          "pub",
-          "global",
-          "run",
           "devtools",
           "--machine",
-          "--try-ports",
-          "10",
         },
         on_stdout = vim.schedule_wrap(handle_start),
         on_stderr = vim.schedule_wrap(handle_error),

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -158,4 +158,13 @@ function M.flutter(callback)
   end)
 end
 
+---Fetch the path to the users dart installation.
+---@param callback fun(paths: table<string, string>)
+---@return nil
+function M.dart(callback)
+  M.get(function(paths)
+    callback(paths.dart_bin)
+  end)
+end
+
 return M


### PR DESCRIPTION
`flutter pub run devtools` is deprecated. Closes #213
