### PR TITLE
fix(dap): use full path to flutter executable when running via DAP

### DIFF
--- a/lua/flutter-tools/dap.lua
+++ b/lua/flutter-tools/dap.lua
@@ -13,7 +13,7 @@ function M.setup(config)
   require("flutter-tools.executable").get(function(paths)
     dap.adapters.dart = {
       type = "executable",
-      command = "flutter",
+      command = paths.flutter_bin,
       args = { "debug-adapter" },
       options = { -- Dartls is slow to start so avoid warnings from nvim-dap
         initialize_timeout_sec = 30,


### PR DESCRIPTION
This fixes the problem with FVM - previously global flutter version was always used. After this change version is picked respecting FVM configuration.