### PR TITLE
refactor(ui)!: replace (some) custom ui with `vim.ui.*`

### DIFF
--- a/.nvim.json
+++ b/.nvim.json
@@ -3,7 +3,8 @@
     "library": {
       "enabled": true,
       "plugins": [
-        "plenary.nvim"
+        "plenary.nvim",
+        "telescope.nvim"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -43,51 +43,46 @@ some basic setup might look like.
 
 - neovim 0.7.0+
 
-## Notices
-
-- This plugin no longer relies on dart code's debugger as flutter and dart now ship with a native debugger.
-  Versions of flutter before version 2.10.0 will still require the old dart code debugger.
-  Setup instructions for this can be found [here](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#dart).
-
-  Migration for existing users of the Dart code debugger on older flutter versions:
-
-  ```lua
-    local debugger_dir = path.join(fn.stdpath("cache"), "dart-code")
-    local debugger_path = path.join(debugger_dir, "out", "dist", "debug.js")
-
-    -- In config section for the debugger
-    debugger = {
-      enabled = true,
-      register.configurations = function()
-        local dap = require("dap")
-        dap.adapters.dart = {
-          type = "executable",
-          command = "node",
-          args = { debugger_path, "flutter" },
-        }
-        -- Other configuration herek
-      end,
-    },
-  ```
-
-- The `:FlutterOutline` command has been renamed to `:FlutterOutlineOpen`, and a `:FlutterOutlineToggle` has been added.
-
 ## Installation
 
 using `vim-plug`
 
 ```vim
 Plug 'nvim-lua/plenary.nvim'
+Plug 'stevearc/dressing.nvim' " optional for vim.ui.select
 Plug 'akinsho/flutter-tools.nvim'
 ```
 
-or using `packer.nvim`
+using `packer.nvim`
 
 ```lua
-use {'akinsho/flutter-tools.nvim', requires = 'nvim-lua/plenary.nvim'}
+use {
+    'akinsho/flutter-tools.nvim',
+    requires = {
+        'nvim-lua/plenary.nvim',
+        'stevearc/dressing.nvim', -- optional for vim.ui.select
+    },
+}
+```
+
+using `lazy.nvim`
+
+```lua
+{
+    'akinsho/flutter-tools.nvim',
+    lazy = false,
+    dependencies = {
+        'nvim-lua/plenary.nvim',
+        'stevearc/dressing.nvim', -- optional for vim.ui.select
+    },
+}
 ```
 
 This plugin depends on [plenary.nvim](https://github.com/nvim-lua/plenary.nvim), please make sure it is installed.
+
+This plugin depends on `vim.ui.select` which allows users to control what UI is used for selecting
+from a list of options. If you don't have a UI configured for `vim.ui.select` then I highly recommend
+the excellent [dressing.nvim](https://github.com/stevearc/dressing.nvim).
 
 ## Warning
 
@@ -103,7 +98,7 @@ This plugin depends on [plenary.nvim](https://github.com/nvim-lua/plenary.nvim),
 
 ```vim
 lua << EOF
-  require("flutter-tools").setup{} -- use defaults
+  require("flutter-tools").setup {} -- use defaults
 EOF
 
 ```
@@ -111,7 +106,7 @@ EOF
 ### Lua
 
 ```lua
-require("flutter-tools").setup{} -- use defaults
+require("flutter-tools").setup {} -- use defaults
 ```
 
 ## Features
@@ -316,17 +311,7 @@ which is where this is usually installed by `snap`.
 
 To configure the highlight colour you can override the `FlutterWidgetGuides` highlight group.
 
-#### Notifications
-
-The highlights for flutter-tools notifications and popups can be changed by overriding the default highlight groups
-
-- `FlutterNotificationNormal` - this changes the highlight of the notification content.
-- `FlutterNotificationBorder` - this changes the highlight of the notification border.
-- `FlutterPopupNormal` - this changes the highlight of the popup content.
-- `FlutterPopupBorder` - this changes the highlight of the popup border.
-- `FlutterPopupSelected` - this changes the highlight of the popup's selected line.
-
-### Statusline decorations (Unstable)
+### Statusline decorations
 
 You can add metadata about the flutter application to your statusline using the `g:flutter_tools_decorations`
 dictionary that is created if you have set any of the decorations to `true` in your configuration.

--- a/ftplugin/flutter_tools_notification.vim
+++ b/ftplugin/flutter_tools_notification.vim
@@ -1,2 +1,0 @@
-highlight default link FlutterNotificationNormal NormalFloat
-highlight default link FlutterNotificationBorder FloatBorder

--- a/ftplugin/flutter_tools_popup.vim
+++ b/ftplugin/flutter_tools_popup.vim
@@ -1,3 +1,0 @@
-highlight default link FlutterPopupSelected Visual
-highlight default link FlutterPopupNormal NormalFloat
-highlight default link FlutterPopupBorder FloatBorder

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -114,6 +114,16 @@ local function setup_autocommands()
     })
   end
 
+  autocmd({ "ColorScheme" }, {
+    group = AUGROUP,
+    callback = function()
+      api.nvim_set_hl(0, "FlutterPopupSelected", { default = true, link = "Visual" })
+      api.nvim_set_hl(0, "FlutterPopupNormal", { default = true, link = "NormalFloat" })
+      api.nvim_set_hl(0, "FlutterPopupBorder", { default = true, link = "FloatBorder" })
+      api.nvim_set_hl(0, "FlutterPopupTitle", { default = true, link = "FloatTitle" })
+    end,
+  })
+
   autocmd({ "BufWritePost" }, {
     group = AUGROUP,
     pattern = { "*.dart" },

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -114,16 +114,6 @@ local function setup_autocommands()
     })
   end
 
-  autocmd({ "ColorScheme" }, {
-    group = AUGROUP,
-    callback = function()
-      api.nvim_set_hl(0, "FlutterPopupSelected", { default = true, link = "Visual" })
-      api.nvim_set_hl(0, "FlutterPopupNormal", { default = true, link = "NormalFloat" })
-      api.nvim_set_hl(0, "FlutterPopupBorder", { default = true, link = "FloatBorder" })
-      api.nvim_set_hl(0, "FlutterPopupTitle", { default = true, link = "FloatTitle" })
-    end,
-  })
-
   autocmd({ "BufWritePost" }, {
     group = AUGROUP,
     pattern = { "*.dart" },

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -241,7 +241,8 @@ function M.pub_get()
       pub_get_job = Job:new({
         command = cmd,
         args = { "pub", "get" },
-        cwd = lsp.get_lsp_root_dir(),--[[@as string]]
+        -- stylua: ignore
+        cwd = lsp.get_lsp_root_dir() --[[@as string]],
       })
       pub_get_job:after_success(vim.schedule_wrap(function(j)
         on_pub_get(j:result())
@@ -273,7 +274,12 @@ function M.pub_upgrade(cmd_args)
       local notify_timeout = 10000
       local args = { "pub", "upgrade" }
       if cmd_args then vim.list_extend(args, cmd_args) end
-      pub_upgrade_job = Job:new({ command = cmd, args = args, cwd = lsp.get_lsp_root_dir() })
+      pub_upgrade_job = Job:new({
+        command = cmd,
+        args = args,
+        -- stylua: ignore
+        cwd = lsp.get_lsp_root_dir() --[[@as string]],
+      })
       pub_upgrade_job:after_success(vim.schedule_wrap(function(j)
         ui.notify(utils.join(j:result()), nil, { timeout = notify_timeout })
         pub_upgrade_job = nil

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -85,7 +85,7 @@ local function on_run_exit(result, cli_args)
   local matched_error, msg = has_recoverable_error(result)
   if matched_error then
     local lines = devices.extract_device_props(result)
-    ui.menu({
+    ui.select({
       title = "Flutter run (" .. msg .. ") ",
       lines = lines,
       on_select = function(device)

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -84,16 +84,12 @@ end
 local function on_run_exit(result, cli_args)
   local matched_error, msg = has_recoverable_error(result)
   if matched_error then
-    local lines, win_devices, highlights = devices.extract_device_props(result)
-    ui.popup_create({
+    local lines = devices.extract_device_props(result)
+    ui.menu({
       title = "Flutter run (" .. msg .. ") ",
       lines = lines,
-      highlights = highlights,
-      on_create = function(buf, _)
-        vim.b.devices = win_devices
-        utils.map("n", "<CR>", function()
-          devices.select_device(cli_args)
-        end, { buffer = buf })
+      on_select = function(device)
+        devices.select_device(device, cli_args)
       end,
     })
   end

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -84,7 +84,7 @@ end
 local function on_run_exit(result, cli_args)
   local matched_error, msg = has_recoverable_error(result)
   if matched_error then
-    local lines = devices.extract_device_props(result)
+    local lines = devices.to_selection_entries(result)
     ui.select({
       title = "Flutter run (" .. msg .. ") ",
       lines = lines,

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -108,7 +108,7 @@ end
 local function show_emulators(result)
   local lines = M.extract_device_props(result, EMULATOR)
   if #lines > 0 then
-    ui.menu({
+    ui.select({
       title = "Flutter emulators",
       lines = lines,
       on_select = M.select_device,
@@ -136,7 +136,7 @@ end
 local function show_devices(job)
   local lines = M.extract_device_props(job:result(), DEVICE)
   if #lines > 0 then
-    ui.menu({
+    ui.select({
       title = "Flutter devices",
       lines = lines,
       on_select = M.select_device,

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -3,9 +3,6 @@ local ui = require("flutter-tools.ui")
 local utils = require("flutter-tools.utils")
 local executable = require("flutter-tools.executable")
 
-local api = vim.api
-local fn = vim.fn
-
 local M = {
   ---@type Job
   emulator_job = nil,
@@ -23,23 +20,6 @@ local function get_devices(result, type)
     if device then table.insert(devices, device) end
   end
   return devices
-end
-
----Highlight each device/emulator in the popup window
----@param highlights table
----@param line string
----@param device table<string, string>
-local function add_device_highlights(highlights, line, device)
-  return ui.get_line_highlights(line, {
-    {
-      word = device.name,
-      highlight = "Type",
-    },
-    {
-      word = device.platform,
-      highlight = "Comment",
-    },
-  }, highlights)
 end
 
 ---@param line string
@@ -65,55 +45,40 @@ end
 ---@param result string[]
 ---@param device_type integer?
 ---@return string[]
----@return table
----@return table<string, string>
 function M.extract_device_props(result, device_type)
-  device_type = device_type or DEVICE
-  local lines = {}
-  local highlights = {}
-  local devices_by_line = {}
+  if not result or #result < 1 then return {} end
+  if not device_type then device_type = DEVICE end
   local devices = get_devices(result, device_type)
-  if #devices > 0 then
-    for _, device in pairs(devices) do
-      local name = utils.display_name(device.name, device.platform)
-      devices_by_line[name] = device
-      add_device_highlights(highlights, name, device)
-      table.insert(lines, name)
-    end
+  if #devices == 0 then
+    vim.tbl_map(function(item)
+      return { text = item, highlight = "Normal" }
+    end, result)
+  end
+  return vim.tbl_map(function(device)
+    local has_platform = device.platform and device.platform ~= ""
+    return {
+      { text = "• ", highlight = "Comment" },
+      { text = device.name, highlight = "Type" },
+      { text = has_platform and " • " or " ", highlight = "Comment" },
+      { text = device.platform, highlight = "Comment" },
+      data = device,
+    }
+  end, devices)
+end
+
+function M.select_device(device, args)
+  if not device then return ui.notify("Sorry there is no device on this line") end
+  local cmd = require("flutter-tools.commands")
+  if device.type == EMULATOR then
+    M.launch_emulator(device)
   else
-    for _, item in pairs(result) do
-      table.insert(lines, item)
-    end
-  end
-  return lines, devices_by_line, highlights
-end
-
-function M.select_device(args)
-  if not vim.b.devices then return ui.notify("Sorry there is no device on this line") end
-  local lnum = fn.line(".")
-  local line = api.nvim_buf_get_lines(0, lnum - 1, lnum, false)
-  local device = vim.b.devices[fn.trim(line[1])]
-  if device then
-    if device.type == EMULATOR then
-      M.launch_emulator(device)
+    if args then
+      vim.list_extend(args, { "-d", device.id })
+      cmd.run({ cli_args = args })
     else
-      if args then
-        vim.list_extend(args, { "-d", device.id })
-        require("flutter-tools.commands").run({ cli_args = args })
-      else
-        require("flutter-tools.commands").run({ device = device })
-      end
+      cmd.run({ device = device })
     end
-    api.nvim_win_close(0, true)
   end
-end
-
----Run commands and setup options after a popup is opened
----@param devices table[]
----@param buf number
-local function setup_window(devices, buf)
-  if not vim.tbl_isempty(devices) then api.nvim_buf_set_var(buf, "devices", devices) end
-  utils.map("n", "<CR>", M.select_device, { buffer = buf })
 end
 
 -----------------------------------------------------------------------------//
@@ -141,15 +106,12 @@ end
 
 ---@param result string[]
 local function show_emulators(result)
-  local lines, emulators, highlights = M.extract_device_props(result, EMULATOR)
+  local lines = M.extract_device_props(result, EMULATOR)
   if #lines > 0 then
-    ui.popup_create({
+    ui.menu({
       title = "Flutter emulators",
       lines = lines,
-      highlights = highlights,
-      on_create = function(buf, _)
-        setup_window(emulators, buf)
-      end,
+      on_select = M.select_device,
     })
   end
 end
@@ -172,16 +134,12 @@ end
 -----------------------------------------------------------------------------//
 ---@param job Job
 local function show_devices(job)
-  local result = job:result()
-  local lines, devices, highlights = M.extract_device_props(result, DEVICE)
+  local lines = M.extract_device_props(job:result(), DEVICE)
   if #lines > 0 then
-    ui.popup_create({
+    ui.menu({
       title = "Flutter devices",
       lines = lines,
-      highlights = highlights,
-      on_create = function(buf, _)
-        setup_window(devices, buf)
-      end,
+      on_select = M.select_device,
     })
   end
 end

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -49,7 +49,7 @@ end
 ---@param result string[]
 ---@param device_type integer?
 ---@return SelectionEntry[]
-function M.extract_device_props(result, device_type)
+function M.to_selection_entries(result, device_type)
   if not result or #result < 1 then return {} end
   if not device_type then device_type = DEVICE end
   local devices = get_devices(result, device_type)
@@ -105,7 +105,7 @@ end
 
 ---@param result string[]
 local function show_emulators(result)
-  local lines = M.extract_device_props(result, EMULATOR)
+  local lines = M.to_selection_entries(result, EMULATOR)
   if #lines > 0 then
     ui.select({
       title = "Flutter emulators",
@@ -133,7 +133,7 @@ end
 -----------------------------------------------------------------------------//
 ---@param job Job
 local function show_devices(job)
-  local lines = M.extract_device_props(job:result(), DEVICE)
+  local lines = M.to_selection_entries(job:result(), DEVICE)
   if #lines > 0 then
     ui.select({
       title = "Flutter devices",

--- a/lua/flutter-tools/devices.lua
+++ b/lua/flutter-tools/devices.lua
@@ -2,6 +2,9 @@ local Job = require("plenary.job")
 local ui = require("flutter-tools.ui")
 local utils = require("flutter-tools.utils")
 local executable = require("flutter-tools.executable")
+local fmt = string.format
+
+---@alias Device {name: string, id: string, platform: string, system: string, type: integer}
 
 local M = {
   ---@type Job
@@ -24,6 +27,7 @@ end
 
 ---@param line string
 ---@param device_type number
+---@return Device?
 function M.parse(line, device_type)
   local parts = vim.split(line, "•")
   local is_emulator = device_type == EMULATOR
@@ -44,23 +48,18 @@ end
 --- return the parsed list and the found devices if any
 ---@param result string[]
 ---@param device_type integer?
----@return string[]
+---@return SelectionEntry[]
 function M.extract_device_props(result, device_type)
   if not result or #result < 1 then return {} end
   if not device_type then device_type = DEVICE end
   local devices = get_devices(result, device_type)
-  if #devices == 0 then
-    vim.tbl_map(function(item)
-      return { text = item, highlight = "Normal" }
-    end, result)
-  end
+  if #devices == 0 then vim.tbl_map(function(item)
+    return { text = item }
+  end, result) end
   return vim.tbl_map(function(device)
     local has_platform = device.platform and device.platform ~= ""
     return {
-      { text = "• ", highlight = "Comment" },
-      { text = device.name, highlight = "Type" },
-      { text = has_platform and " • " or " ", highlight = "Comment" },
-      { text = device.platform, highlight = "Comment" },
+      text = fmt(" %s %s ", device.name, has_platform and " • " .. device.platform or " "),
       data = device,
     }
   end, devices)

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -144,7 +144,7 @@ function M.get(callback)
 end
 
 ---Fetch the path to the users flutter installation.
----@param callback fun(paths: table<string, string>)
+---@param callback fun(paths: string)
 ---@return nil
 function M.flutter(callback)
   M.get(function(paths)

--- a/lua/flutter-tools/lsp/code_actions.lua
+++ b/lua/flutter-tools/lsp/code_actions.lua
@@ -50,7 +50,7 @@ function M.create_popup(actions, on_create)
     return action.title:gsub("\r\n", "\\r\\n"):gsub("\n", "\\n")
   end, actions)
 
-  require("flutter-tools.ui").popup_create({
+  require("flutter-tools.ui").menu({
     title = "Code actions",
     display = { winblend = 0 },
     position = { relative = "cursor", row = 1, col = 0 },

--- a/lua/flutter-tools/lsp/code_actions.lua
+++ b/lua/flutter-tools/lsp/code_actions.lua
@@ -50,7 +50,7 @@ function M.create_popup(actions, on_create)
     return action.title:gsub("\r\n", "\\r\\n"):gsub("\n", "\\n")
   end, actions)
 
-  require("flutter-tools.ui").menu({
+  require("flutter-tools.ui").select({
     title = "Code actions",
     display = { winblend = 0 },
     position = { relative = "cursor", row = 1, col = 0 },

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -20,7 +20,7 @@ local function analysis_server_snapshot_path(sdk_path)
 end
 
 ---Merge a set of default configurations with a user's own settings
----NOTE: a user can specify a function in which case this will be used
+--- NOTE: a user can specify a function in which case this will be used
 ---to determine how to merge the defaults with a user's config
 ---@param default table
 ---@param user table|function
@@ -103,16 +103,10 @@ local function get_defaults(opts)
       -- @see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspaceEdit
       capabilities.workspace.workspaceEdit.documentChanges = true
       capabilities.textDocument.completion.completionItem.snippetSupport = true
-      capabilities.textDocument.documentColor = {
-        dynamicRegistration = true,
-      }
+      capabilities.textDocument.documentColor = { dynamicRegistration = true }
       -- @see: https://github.com/hrsh7th/nvim-compe#how-to-use-lsp-snippet
       capabilities.textDocument.completion.completionItem.resolveSupport = {
-        properties = {
-          "documentation",
-          "detail",
-          "additionalTextEdits",
-        },
+        properties = { "documentation", "detail", "additionalTextEdits" },
       }
       return capabilities
     end)(),
@@ -135,7 +129,7 @@ function M.restart()
 end
 
 ---@param server_name string?
----@return table?
+---@return lsp.Client?
 local function get_dartls_client(server_name)
   server_name = server_name or SERVER_NAME
   return lsp.get_active_clients({ name = server_name })[1]

--- a/lua/flutter-tools/menu.lua
+++ b/lua/flutter-tools/menu.lua
@@ -24,7 +24,7 @@ end
 local function command_entry_maker(max_width)
   local make_display = function(en)
     local displayer = entry_display.create({
-      separator = en.hint ~= "" and " - " or "",
+      separator = en.hint ~= "" and " • " or "",
       items = {
         { width = max_width },
         { remaining = true },
@@ -55,7 +55,16 @@ local function get_max_length(commands)
   return max
 end
 
-function M.commands(opts)
+---@param items {hint: string, label: string, command: fun(), id: integer}[]
+---@return table
+function M.telescope_finder(items)
+  return finders.new_table({
+    results = items,
+    entry_maker = command_entry_maker(get_max_length(items)),
+  })
+end
+
+function M.commands()
   local commands = {}
 
   local commands_module = require("flutter-tools.commands")
@@ -198,10 +207,7 @@ function M.commands(opts)
   pickers
     .new(picker_opts, {
       prompt_title = "Flutter tools commands",
-      finder = finders.new_table({
-        results = commands,
-        entry_maker = command_entry_maker(get_max_length(commands)),
-      }),
+      finder = M.telescope_finder(commands),
       sorter = sorters.get_generic_fuzzy_sorter(),
       attach_mappings = function(_, map)
         map("i", "<CR>", execute_command)

--- a/lua/flutter-tools/outline.lua
+++ b/lua/flutter-tools/outline.lua
@@ -364,7 +364,7 @@ local function request_code_actions()
     params,
     utils.lsp_handler(function(_, actions, _)
       code_actions.create_popup(actions, function(buf, win)
-        utils.map(
+        vim.keymap.set(
           "n",
           "<CR>",
           select_code_action(actions, win, code_buf, code_win, outline_win),
@@ -412,9 +412,9 @@ local function setup_outline_window(buf, win, lines, highlights, _)
     ui.add_highlights(state.outline_buf, highlights)
   end
 
-  utils.map("n", "q", "<Cmd>bw!<CR>", { nowait = true, buffer = buf })
-  utils.map("n", "<CR>", select_outline_item, { buffer = buf, nowait = true })
-  utils.map("n", "a", request_code_actions, { buffer = buf, nowait = true })
+  vim.keymap.set("n", "q", "<Cmd>bw!<CR>", { nowait = true, buffer = buf })
+  vim.keymap.set("n", "<CR>", select_outline_item, { buffer = buf, nowait = true })
+  vim.keymap.set("n", "a", request_code_actions, { buffer = buf, nowait = true })
 
   setup_autocommands()
 end

--- a/lua/flutter-tools/outline.lua
+++ b/lua/flutter-tools/outline.lua
@@ -329,7 +329,7 @@ local function select_code_action(actions, action_win, code_buf, code_win, outli
         end, 500)
       end)
     end
-    if api.nvim_win_is_valid(action_win) then vim.api.nvim_win_close(action_win, true) end
+    if api.nvim_win_is_valid(action_win) then api.nvim_win_close(action_win, true) end
   end
 end
 
@@ -371,7 +371,7 @@ local function request_code_actions()
           { buffer = buf }
         )
       end)
-      vim.api.nvim_win_set_cursor(code_win, { item.start_line + 1, item.start_col + 1 })
+      api.nvim_win_set_cursor(code_win, { item.start_line + 1, item.start_col + 1 })
     end)
   )
 end

--- a/lua/flutter-tools/ui.lua
+++ b/lua/flutter-tools/ui.lua
@@ -1,3 +1,9 @@
+if not pcall(require, "nui.menu") then error("nui not found, please install it") end
+
+local Menu = require("nui.menu")
+local Text = require("nui.text")
+local Line = require("nui.line")
+
 local utils = require("flutter-tools.utils")
 local fmt = string.format
 
@@ -10,66 +16,22 @@ local M = {
 }
 
 local api = vim.api
-local fn = vim.fn
 local namespace_id = api.nvim_create_namespace("flutter_tools_popups")
 
-local WIN_BLEND = 5
-
-local function close(buf)
-  vim.api.nvim_buf_delete(buf, { force = true })
-end
-
----Create a reverse look up to find a lines number in a buffer
----based on it's content
----@param buf integer
----@return table<string, integer>
-local function create_buf_lookup(buf)
-  local lnum_by_line = {}
-  for lnum, line in ipairs(api.nvim_buf_get_lines(buf, 0, -1, false)) do
-    lnum_by_line[fn.trim(line)] = lnum - 1
-  end
-  return lnum_by_line
-end
-
----@param lines string[]
-local function pad_lines(lines)
-  local formatted = {}
-  for _, line in pairs(lines) do
-    table.insert(formatted, " " .. line .. " ")
-  end
-  return formatted
-end
-
----@param lines string[]
-local function calculate_width(lines)
-  local max_width = math.ceil(vim.o.columns * 0.8)
-  local max_length = 0
-  for _, line in pairs(lines) do
-    if #line > max_length then max_length = #line end
-  end
-  return max_length <= max_width and max_length or max_width
-end
+-- ---@param lines string[]
+-- local function calculate_width(lines)
+--   local max_width = math.ceil(vim.o.columns * 0.8)
+--   local max_length = 0
+--   for _, line in pairs(lines) do
+--     if #line > max_length then max_length = #line end
+--   end
+--   return max_length <= max_width and max_length or max_width
+-- end
 
 function M.clear_highlights(buf_id, ns_id, line_start, line_end)
   line_start = line_start or 0
   line_end = line_end or -1
   api.nvim_buf_clear_namespace(buf_id, ns_id, line_start, line_end)
-end
-
-function M.get_line_highlights(line, items, highlights)
-  highlights = highlights or {}
-  for _, item in ipairs(items) do
-    local match_start, match_end = line:find(vim.pesc(item.word))
-    if match_start and match_end then
-      highlights[line] = highlights[line] or {}
-      table.insert(highlights[line], {
-        highlight = item.highlight,
-        column_start = match_start,
-        column_end = match_end + 1,
-      })
-    end
-  end
-  return highlights
 end
 
 --- @param buf_id number
@@ -117,93 +79,53 @@ M.notify = function(msg, level, opts)
   })
 end
 
----@class PopupOpts
----@field title string
----@field lines string[]
----@field display table
----@field position table
----@field on_create fun(buf: number, win:number):nil
----@field highlights table[]
-
---- TODO: Ideally popup_create should include a mechanism for mapping data to a line
+---@alias PopupOpts {title:string, lines:{text: string, highlight: string, data: table}[], on_select: fun(device: table)}
 ---@param opts PopupOpts
-function M.popup_create(opts)
+function M.menu(opts)
   assert(opts ~= nil, "An options table must be passed to popup create!")
-  local title = opts.title
-  local lines = opts.lines
-  local on_create = opts.on_create
-  local highlights = opts.highlights or {}
-  local display = opts.display or { winblend = WIN_BLEND }
-  local position = opts.position or {}
+  local title, lines, on_select = opts.title, opts.lines, opts.on_select
+  local config = require("flutter-tools.config").get("ui")
 
   if not lines or #lines < 1 or invalid_lines(lines) then return end
 
-  lines = pad_lines(lines)
-  local width = calculate_width(lines)
-  local height = 10
-  local buf = api.nvim_create_buf(false, true)
-  lines = { title, string.rep("─", width), unpack(lines) }
-
-  position.relative = position.relative or "editor"
-  position.row = position.row or (vim.o.lines - height) / 2
-  position.col = position.col or (vim.o.columns - width) / 2
-
-  api.nvim_buf_set_lines(buf, 0, -1, true, lines)
-  local win = api.nvim_open_win(buf, true, {
-    row = position.row,
-    col = position.col,
-    relative = position.relative,
-    style = "minimal",
-    width = width,
-    height = height,
-    border = require("flutter-tools.config").get("ui").border,
+  local menu = Menu({
+    position = "50%",
+    border = {
+      style = config.border,
+      text = { top = title, top_align = "center" },
+    },
+    win_options = {
+      winhighlight = table.concat({
+        "CursorLine:FlutterPopupSelected",
+        "NormalFloat:FlutterPopupNormal",
+        "Normal:FlutterPopupNormal",
+        "EndOfBuffer:FlutterPopupNormal",
+        "FloatTitle:FlutterPopupTitle",
+        "FloatBorder:FlutterPopupBorder",
+      }, ","),
+    },
+  }, {
+    lines = vim.tbl_map(function(line)
+      local words = vim.tbl_map(function(word)
+        return Text(word.text, word.highlight)
+      end, line)
+      return Menu.item(Line(words), line.data)
+    end, lines),
+    min_height = 10,
+    max_width = 50,
+    keymap = {
+      focus_next = { "j", "<Down>", "<Tab>" },
+      focus_prev = { "k", "<Up>", "<S-Tab>" },
+      close = { "<Esc>", "q" },
+      submit = { "<CR>", "<Space>" },
+    },
+    on_submit = function(item)
+      print("DEBUGPRINT[1]: ui.lua:124: item=" .. vim.inspect(item.data))
+      on_select(item)
+    end,
   })
 
-  local buf_highlights = {
-    { highlight = "Title", line_number = 0, column_end = #title, column_start = 0 },
-    { highlight = "FloatBorder", line_number = 1, column_start = 0, column_end = -1 },
-  }
-  local lookup = create_buf_lookup(buf)
-  for key, value in pairs(highlights) do
-    local lnum = lookup[fn.trim(key)]
-    if lnum then
-      for _, hl in ipairs(value) do
-        hl.line_number = lnum
-        buf_highlights[#buf_highlights + 1] = hl
-      end
-    end
-  end
-
-  M.add_highlights(buf, buf_highlights)
-
-  vim.bo.filetype = "flutter_tools_popup"
-  vim.wo[win].winblend = display.winblend
-  vim.bo[buf].modifiable = false
-  vim.wo[win].cursorline = true
-  --- Positions cursor on the third line i.e. after the title and it's underline
-  api.nvim_win_set_cursor(win, { 3, 0 })
-  vim.wo[win].winhighlight = table.concat({
-    "CursorLine:FlutterPopupSelected",
-    "NormalFloat:FlutterPopupNormal",
-    "Normal:FlutterPopupNormal",
-    "EndOfBuffer:FlutterPopupNormal",
-    "FloatBorder:FlutterPopupBorder",
-  }, ",")
-
-  utils.map("n", "q", function()
-    close(buf)
-  end, {
-    buffer = buf,
-    nowait = true,
-  })
-  utils.map("n", "<ESC>", function()
-    close(buf)
-  end, {
-    buffer = buf,
-    nowait = true,
-  })
-  vim.cmd(string.format([[autocmd! WinLeave <buffer> silent! execute 'bw %d']], buf))
-  if on_create then on_create(buf, win) end
+  menu:mount()
 end
 
 ---Create a split window

--- a/lua/flutter-tools/ui.lua
+++ b/lua/flutter-tools/ui.lua
@@ -98,6 +98,7 @@ function M.select(opts)
     format_item = function(item)
       return item.text
     end,
+    -- custom key for dressing.nvim
     telescope = custom_telescope_picker(lines, on_select),
   }, function(item)
     if not item then return end

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -2,21 +2,6 @@ local M = {}
 local fn = vim.fn
 local api = vim.api
 
--- FIXME: remove this when lua autocommands are officially supported
--- Global store of callback for autocommand (and eventually mappings)
-_G.__flutter_tools_callbacks = __flutter_tools_callbacks or {}
-
----@param name string
----@return string
-function M.display_name(name, platform)
-  if not name then return "" end
-  local symbol = "•"
-  return symbol
-    .. " "
-    .. name
-    .. (platform and platform ~= "" and (" " .. symbol .. " ") .. platform or "")
-end
-
 --- if every item in a table is an empty value return true
 function M.list_is_empty(tbl)
   if not tbl then return true end

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -15,40 +15,6 @@ function M.buf_valid(bufnr, name)
   return vim.fn.bufexists(target) > 0 and vim.fn.buflisted(target) > 0
 end
 
----Add a function to the global callback map
----@param f function
----@return number
-local function _create(f)
-  table.insert(__flutter_tools_callbacks, f)
-  return #__flutter_tools_callbacks
-end
-
-function M._execute(id, args)
-  __flutter_tools_callbacks[id](args)
-end
-
----Create a mapping
----@param mode string
----@param lhs string
----@param rhs string | function
----@param opts table
-function M.map(mode, lhs, rhs, opts)
-  -- add functions to a global table keyed by their index
-  if type(rhs) == "function" then
-    local fn_id = _create(rhs)
-    rhs = string.format("<cmd>lua require('flutter-tools.utils')._execute(%s)<CR>", fn_id)
-  end
-  local buffer = opts.buffer
-  opts.silent = opts.silent ~= nil and opts.silent or true
-  opts.noremap = opts.noremap ~= nil and opts.noremap or true
-  opts.buffer = nil
-  if buffer and type(buffer) == "number" then
-    api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, opts)
-  else
-    api.nvim_set_keymap(mode, lhs, rhs, opts)
-  end
-end
-
 local colorscheme_group = api.nvim_create_augroup("FlutterToolsColorscheme", { clear = true })
 ---Add a highlight group and an accompanying autocommand to refresh it
 ---if the colorscheme changes


### PR DESCRIPTION
When this plugin was first created almost none of the cool new APIs for making plugins existed. So I hand rolled a bunch of things like the menus, the tree layout etc. This stuff now accounts for like 40% of all the code in this repository if not more and there are now well implemented and tested libraries like nui.nvim which provide components for inputs, menus, trees, splits and other complex layouts. 

To simplify maintenance this PR removes all the custom logic for in favour of using nui.nvim for as much/all the custom UI.