### PR TITLE
feat: add FlutterRename command

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ require("flutter-tools").setup {} -- use defaults
 - `FlutterLspRestart` - This command restarts the dart language server, and is intended for situations where it begins to work incorrectly.
 - `FlutterSuper` - Go to super class, method using custom LSP method `dart/textDocument/super`.
 - `FlutterReanalyze` - Forces LSP server reanalyze using custom LSP method `dart/reanalyze`.
-- `FlutterRename` - Renames and updates imports if needed.
+- `FlutterRename` - Renames and updates imports if `lsp.settings.renameFilesWithClasses == "always"`
 
 <hr/>
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ require("flutter-tools").setup {} -- use defaults
 - `FlutterLspRestart` - This command restarts the dart language server, and is intended for situations where it begins to work incorrectly.
 - `FlutterSuper` - Go to super class, method using custom LSP method `dart/textDocument/super`.
 - `FlutterReanalyze` - Forces LSP server reanalyze using custom LSP method `dart/reanalyze`.
+- `FlutterRename` - Renames and updates imports if needed.
 
 <hr/>
 
@@ -273,6 +274,7 @@ require("flutter-tools").setup {
       analysisExcludedFolders = {"<path-to-flutter-sdk-packages>"},
       renameFilesWithClasses = "prompt", -- "always"
       enableSnippets = true,
+      updateImportsOnRename = true, -- Whether to update imports and other directives when files are renamed. Required for `FlutterRename` command.
     }
   }
 }

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -48,6 +48,7 @@ local function setup_commands()
   --- LSP
   command("FlutterSuper", lsp.dart_lsp_super)
   command("FlutterReanalyze", lsp.dart_reanalyze)
+  command("FlutterRename", function() require("flutter-tools.lsp.rename").rename() end)
 end
 
 ---Initialise various plugin modules

--- a/lua/flutter-tools/lsp/color/init.lua
+++ b/lua/flutter-tools/lsp/color/init.lua
@@ -1,15 +1,16 @@
 local M = {}
 
+local lazy = require("flutter-tools.lazy")
+local lsp_utils = lazy.require("flutter-tools.lsp.utils") ---@module "flutter-tools.lsp.utils"
+
 function M.document_color()
   local params = {
     textDocument = vim.lsp.util.make_text_document_params(),
   }
 
-  local clients = vim.lsp.get_active_clients({ name = "dartls" })
-  for _, client in ipairs(clients) do
-    if client.server_capabilities.colorProvider then
-      client.request("textDocument/documentColor", params, nil, 0)
-    end
+  local client = lsp_utils.get_dartls_client()
+  if client and client.server_capabilities.colorProvider then
+    client.request("textDocument/documentColor", params, nil, 0)
   end
 end
 

--- a/lua/flutter-tools/lsp/commands.lua
+++ b/lua/flutter-tools/lsp/commands.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+local lazy = require("flutter-tools.lazy")
+local ui = lazy.require("flutter-tools.ui") ---@module "flutter-tools.ui"
+
 function M.refactor_perform(command, ctx)
   local client = vim.lsp.get_client_by_id(ctx.client_id)
 
@@ -24,8 +27,7 @@ function M.refactor_perform(command, ctx)
     prompt = prompt,
     default = default,
   }
-
-  local on_confirm = function(name)
+  ui.input(opts, function(name)
     if not name then return end
     -- The 6th argument is the additional options of the refactor command.
     -- For the extract method/local variable/widget commands, we can specify an optional `name` option.
@@ -33,13 +35,7 @@ function M.refactor_perform(command, ctx)
     local optionsIndex = 6
     command.arguments[optionsIndex] = { name = name }
     client.request("workspace/executeCommand", command)
-  end
-  if vim.ui and vim.ui.input then
-    vim.ui.input(opts, on_confirm)
-  else
-    local input = vim.fn.input(opts)
-    if #input > 0 then on_confirm(input) end
-  end
+  end)
 end
 
 return M

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -75,6 +75,7 @@ local function get_defaults(opts)
           path.join(flutter_sdk_path, "packages"),
           path.join(flutter_sdk_path, ".pub-cache"),
         },
+        updateImportsOnRename = true,
       },
     },
     handlers = {
@@ -149,9 +150,9 @@ M.document_color = function()
   local active_clients = vim.tbl_map(function(c) return c.id end, vim.lsp.get_active_clients())
   local dartls = get_dartls_client()
   if
-    dartls
-    and vim.tbl_contains(active_clients, dartls.id)
-    and dartls.server_capabilities.colorProvider
+      dartls
+      and vim.tbl_contains(active_clients, dartls.id)
+      and dartls.server_capabilities.colorProvider
   then
     color.document_color()
   end
@@ -222,10 +223,10 @@ function M.attach()
 
   get_server_config(user_config, function(c)
     c.root_dir = M.get_lsp_root_dir()
-      or fs.dirname(fs.find(ROOT_PATTERNS, {
-        path = buffer_path,
-        upward = true,
-      })[1])
+        or fs.dirname(fs.find(ROOT_PATTERNS, {
+          path = buffer_path,
+          upward = true,
+        })[1])
     vim.lsp.start(c)
   end)
 end

--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -150,9 +150,9 @@ M.document_color = function()
   local active_clients = vim.tbl_map(function(c) return c.id end, vim.lsp.get_active_clients())
   local dartls = get_dartls_client()
   if
-      dartls
-      and vim.tbl_contains(active_clients, dartls.id)
-      and dartls.server_capabilities.colorProvider
+    dartls
+    and vim.tbl_contains(active_clients, dartls.id)
+    and dartls.server_capabilities.colorProvider
   then
     color.document_color()
   end
@@ -223,10 +223,10 @@ function M.attach()
 
   get_server_config(user_config, function(c)
     c.root_dir = M.get_lsp_root_dir()
-        or fs.dirname(fs.find(ROOT_PATTERNS, {
-          path = buffer_path,
-          upward = true,
-        })[1])
+      or fs.dirname(fs.find(ROOT_PATTERNS, {
+        path = buffer_path,
+        upward = true,
+      })[1])
     vim.lsp.start(c)
   end)
 end

--- a/lua/flutter-tools/lsp/rename.lua
+++ b/lua/flutter-tools/lsp/rename.lua
@@ -1,9 +1,11 @@
 local M = {}
 
-local api = vim.api
-local util = vim.lsp.util
 local lazy = require("flutter-tools.lazy")
 local path = lazy.require("flutter-tools.utils.path") ---@module "flutter-tools.utils.path"
+local lsp_utils = lazy.require("flutter-tools.lsp.utils") ---@module "flutter-tools.lsp.utils"
+
+local api = vim.api
+local util = vim.lsp.util
 
 --- Computes a filename for a given class name (convert from PascalCase to  snake_case).
 local function file_name_for_class_name(class_name)
@@ -38,11 +40,7 @@ end
 function M.rename(new_name, options)
   options = options or {}
   local bufnr = options.bufnr or api.nvim_get_current_buf()
-  local clients = vim.lsp.get_active_clients({
-    bufnr = bufnr,
-    name = "dartls",
-  })
-  local client = clients[1]
+  local client = lsp_utils.get_dartls_client(bufnr)
   if not client then
     -- Fallback to default rename function if language server is not dartls
     vim.lsp.buf.rename(new_name, options)

--- a/lua/flutter-tools/lsp/rename.lua
+++ b/lua/flutter-tools/lsp/rename.lua
@@ -72,7 +72,7 @@ function M.rename(new_name, options)
     local params = util.make_position_params(win, client.offset_encoding)
     params.newName = name
     local handler = client.handlers["textDocument/rename"]
-        or vim.lsp.handlers["textDocument/rename"]
+      or vim.lsp.handlers["textDocument/rename"]
     client.request("textDocument/rename", params, function(...)
       handler(...)
       if will_rename_files_result then
@@ -100,7 +100,7 @@ function M.rename(new_name, options)
     client.request("textDocument/prepareRename", params, function(err, result)
       if err or result == nil then
         local msg = err and ("Error on prepareRename: " .. (err.message or ""))
-            or "Nothing to rename"
+          or "Nothing to rename"
         vim.notify(msg, vim.log.levels.INFO)
         return
       end

--- a/lua/flutter-tools/lsp/rename.lua
+++ b/lua/flutter-tools/lsp/rename.lua
@@ -1,0 +1,149 @@
+local M = {}
+
+local api = vim.api
+local util = vim.lsp.util
+local lazy = require("flutter-tools.lazy")
+local path = lazy.require("flutter-tools.utils.path") ---@module "flutter-tools.utils.path"
+
+--- Computes a filename for a given class name (convert from PascalCase to  snake_case).
+local function file_name_for_class_name(class_name)
+  local starts_uppercase = class_name:find("^%u")
+  if not starts_uppercase then return nil end
+  local file_name = class_name:gsub("(%u)", "_%1"):lower()
+  -- Removes first underscore
+  file_name = file_name:sub(2)
+  return file_name .. ".dart"
+end
+
+local function will_rename_files(old_name, new_name, callback)
+  local params = vim.lsp.util.make_position_params()
+  if not new_name then return end
+  local file_change = {
+    newUri = vim.uri_from_fname(new_name),
+    oldUri = vim.uri_from_fname(old_name),
+  }
+  params.files = { file_change }
+  vim.lsp.buf_request(0, "workspace/willRenameFiles", params, function(err, result)
+    if err then
+      vim.notify(err.message or "Error on getting lsp rename results!")
+      return
+    end
+    callback(result)
+  end)
+end
+
+--- Call this function when you want rename class or anything else.
+--- If file will be renamed too, this function will update imports.
+--- Function has same signature as `vim.lsp.buf.rename()` function and can be used instead of it.
+function M.rename(new_name, options)
+  options = options or {}
+  local bufnr = options.bufnr or api.nvim_get_current_buf()
+  local clients = vim.lsp.get_active_clients({
+    bufnr = bufnr,
+    name = "dartls",
+  })
+  local client = clients[1]
+  if not client then
+    -- Fallback to default rename function if language server is not dartls
+    vim.lsp.buf.rename(new_name, options)
+    return
+  end
+
+  local win = api.nvim_get_current_win()
+
+  -- Compute early to account for cursor movements after going async
+  local cword = vim.fn.expand("<cword>")
+  local actual_file_name = vim.fn.expand("%:t")
+  local old_computed_filename = file_name_for_class_name(cword)
+  local is_file_rename = old_computed_filename == actual_file_name
+
+  local function get_text_at_range(range, offset_encoding)
+    return api.nvim_buf_get_text(
+      bufnr,
+      range.start.line,
+      util._get_line_byte_from_position(bufnr, range.start, offset_encoding),
+      range["end"].line,
+      util._get_line_byte_from_position(bufnr, range["end"], offset_encoding),
+      {}
+    )[1]
+  end
+
+  local function rename(name, will_rename_files_result)
+    local params = util.make_position_params(win, client.offset_encoding)
+    params.newName = name
+    local handler = client.handlers["textDocument/rename"]
+        or vim.lsp.handlers["textDocument/rename"]
+    client.request("textDocument/rename", params, function(...)
+      handler(...)
+      if will_rename_files_result then
+        -- the `will_rename_files_result` contains all the places we need to update imports
+        -- so we apply those edits.
+        vim.lsp.util.apply_workspace_edit(will_rename_files_result, client.offset_encoding)
+      end
+    end, bufnr)
+  end
+
+  local function rename_fix_imports(name)
+    if is_file_rename then
+      local old_file_path = vim.fn.expand("%:p")
+      local new_filename = file_name_for_class_name(name)
+      local actual_file_head = vim.fn.expand("%:p:h")
+      local new_file_path = path.join(actual_file_head, new_filename)
+      will_rename_files(old_file_path, new_file_path, function(result) rename(name, result) end)
+    else
+      rename(name)
+    end
+  end
+
+  if client.supports_method("textDocument/prepareRename") then
+    local params = util.make_position_params(win, client.offset_encoding)
+    client.request("textDocument/prepareRename", params, function(err, result)
+      if err or result == nil then
+        local msg = err and ("Error on prepareRename: " .. (err.message or ""))
+            or "Nothing to rename"
+        vim.notify(msg, vim.log.levels.INFO)
+        return
+      end
+
+      if new_name then
+        rename_fix_imports(new_name)
+        return
+      end
+
+      local prompt_opts = {
+        prompt = "New Name: ",
+      }
+      -- result: Range | { range: Range, placeholder: string }
+      if result.placeholder then
+        prompt_opts.default = result.placeholder
+      elseif result.start then
+        prompt_opts.default = get_text_at_range(result, client.offset_encoding)
+      elseif result.range then
+        prompt_opts.default = get_text_at_range(result.range, client.offset_encoding)
+      else
+        prompt_opts.default = cword
+      end
+      vim.ui.input(prompt_opts, function(input)
+        if not input or #input == 0 then return end
+        rename_fix_imports(input)
+      end)
+    end, bufnr)
+  else
+    assert(client.supports_method("textDocument/rename"), "Client must support textDocument/rename")
+    if new_name then
+      rename_fix_imports(new_name)
+      return
+    end
+
+    local prompt_opts = {
+      prompt = "New Name: ",
+      default = cword,
+    }
+    vim.ui.input(prompt_opts, function(input)
+      if not input or #input == 0 then return end
+      rename_fix_imports(input)
+    end)
+  end
+end
+
+return M

--- a/lua/flutter-tools/lsp/rename.lua
+++ b/lua/flutter-tools/lsp/rename.lua
@@ -75,8 +75,7 @@ function M.rename(new_name, options)
     client.request("textDocument/rename", params, function(...)
       handler(...)
       if will_rename_files_result then
-        -- the `will_rename_files_result` contains all the places we need to update imports
-        -- so we apply those edits.
+        -- `will_rename_files_result` contains all the places we need to update imports, so we apply those edits.
         lsp.util.apply_workspace_edit(will_rename_files_result, client.offset_encoding)
       end
     end, bufnr)
@@ -104,14 +103,9 @@ function M.rename(new_name, options)
         return
       end
 
-      if new_name then
-        rename_fix_imports(new_name)
-        return
-      end
+      if new_name then return rename_fix_imports(new_name) end
 
-      local prompt_opts = {
-        prompt = "New Name: ",
-      }
+      local prompt_opts = { prompt = "New Name: " }
       -- result: Range | { range: Range, placeholder: string }
       if result.placeholder then
         prompt_opts.default = result.placeholder
@@ -122,7 +116,7 @@ function M.rename(new_name, options)
       else
         prompt_opts.default = cword
       end
-      vim.ui.input(prompt_opts, function(input)
+      ui.input(prompt_opts, function(input)
         if not input or #input == 0 then return end
         rename_fix_imports(input)
       end)
@@ -138,7 +132,7 @@ function M.rename(new_name, options)
       prompt = "New Name: ",
       default = cword,
     }
-    vim.ui.input(prompt_opts, function(input)
+    ui.input(prompt_opts, function(input)
       if not input or #input == 0 then return end
       rename_fix_imports(input)
     end)

--- a/lua/flutter-tools/lsp/rename.lua
+++ b/lua/flutter-tools/lsp/rename.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local lazy = require("flutter-tools.lazy")
+local config = lazy.require("flutter-tools.config") ---@module "flutter-tools.config"
 local lsp_utils = lazy.require("flutter-tools.lsp.utils") ---@module "flutter-tools.lsp.utils"
 local path = lazy.require("flutter-tools.utils.path") ---@module "flutter-tools.utils.path"
 local ui = lazy.require("flutter-tools.ui") ---@module "flutter-tools.ui"
@@ -50,8 +51,9 @@ function M.rename(new_name, options)
   options = options or {}
   local bufnr = options.bufnr or api.nvim_get_current_buf()
   local client = lsp_utils.get_dartls_client(bufnr)
-  if not client then
+  if not client or config.lsp.settings.renameFilesWithClasses ~= "always" then
     -- Fallback to default rename function if language server is not dartls
+    -- or if user doesn't want to rename files on class rename.
     return lsp.buf.rename(new_name, options)
   end
 

--- a/lua/flutter-tools/lsp/utils.lua
+++ b/lua/flutter-tools/lsp/utils.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+local lsp = vim.lsp
+
+M.SERVER_NAME = "dartls"
+
+---@param bufnr number?
+---@return lsp.Client?
+function M.get_dartls_client(bufnr)
+  return lsp.get_active_clients({ name = M.SERVER_NAME, bufnr = bufnr })[1]
+end
+
+return M

--- a/lua/flutter-tools/ui.lua
+++ b/lua/flutter-tools/ui.lua
@@ -74,6 +74,10 @@ M.notify = function(msg, level, opts)
   })
 end
 
+---@param opts table
+---@param on_confirm function
+M.input = function(opts, on_confirm) vim.ui.input(opts, on_confirm) end
+
 --- @param items SelectionEntry[]
 --- @param title string
 --- @param on_select fun(item: SelectionEntry)


### PR DESCRIPTION
This command adds support for `updateImportsOnRename` setting (https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md#client-workspace-configuration). 

It is useful when the file is renamed after a class rename (when enabled `renameFilesWithClasses` setting). 
It will fall back to `vim.lsp.buf.rename()` if no `dartls` client is found. 
If the client is found, the file is the same as the class name, and the class is being renamed,  it will request for changes via `workspace/willRenameFiles`. Results of `workspace/willRenameFiles` will be applied after the class rename.

To test it try to rename the class that is in the file with the same file name. 

- with `vim.lsp.buf.rename()`: class renamed, file renamed, usage of class renamed, but imports are not updated.
- with `FlutterRename`: class renamed, file renamed, usage and imports are updated.