### PR TITLE
feat(commands): add option to silence flutter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ require("flutter-tools").setup {
   },
   dev_log = {
     enabled = true,
+    notify_errors = false, -- if there is an error whilst running then notify the user
     open_cmd = "tabedit", -- command to use to open the log buffer
   },
   dev_tools = {

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -66,12 +66,12 @@ end
 ---Handle output from flutter run command
 ---@param is_err boolean if this is stdout or stderr
 local function on_run_data(is_err, data)
-  if is_err then ui.notify(data, ui.ERROR, { timeout = 5000 }) end
+  if is_err and config.dev_log.notify_errors then ui.notify(data, ui.ERROR, { timeout = 5000 }) end
   dev_log.log(data, config.dev_log)
 end
 
 local function shutdown()
-  if runner ~= nil then runner:cleanup() end
+  if runner then runner:cleanup() end
   runner = nil
   current_device = nil
   utils.emit_event(utils.events.PROJECT_CONFIG_CHANGED)

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -121,6 +121,7 @@ local config = {
   }),
   dev_log = setmetatable({
     enabled = true,
+    notify_errors = false,
   }, {
     __index = function(_, k) return k == "open_cmd" and get_split_cmd(0.4, 50) or nil end,
   }),
@@ -159,7 +160,7 @@ function M.set(user_config)
   for key, value in pairs(user_config) do
     handle_deprecation(key, value, user_config)
   end
-  config = require("flutter-tools.utils").merge(config, user_config)
+  config = vim.tbl_deep_extend("force", config, user_config)
   return config
 end
 


### PR DESCRIPTION
Whilst the dev log is being populated it receives output from stdout/stderr, if from stderr this is passed on the `vim.notify` this can be very noisy though so this adds an option to silence these notifications

fixes #197