### PR TITLE
Support nested dart sdk

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -44,7 +44,18 @@ end
 local function _flutter_sdk_dart_bin(flutter_sdk)
   -- retrieve the Dart binary from the Flutter SDK
   local binary_name = path.is_windows and "dart.bat" or "dart"
-  return path.join(flutter_sdk, "bin", binary_name)
+  local dart_search_paths = {
+    path.join(flutter_sdk, "bin", binary_name),
+    path.join(flutter_sdk, "bin", "cache", "dart-sdk", "bin", binary_name)
+  }
+
+  for _, _path in ipairs(dart_search_paths) do
+    if path.exists(_path) then
+      return _path
+    end
+  end
+
+  return ""
 end
 
 ---Get paths for flutter and dart based on the binary locations


### PR DESCRIPTION
Some system like NixOS, the dart is nested within `flutter/bin` which leads to the error where dart will not be found as current implementation. This patch adds the `flutter/bin/cache/dart-sdk/bin` to the search paths along with `flutter/bin`. This is short term solution, for long term, IMO we can search for the executable dart within `flutter/bin`.