### PR TITLE
Allow using different flutter binaries for the sdk and flutter itself

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -120,7 +120,8 @@ function M.get(callback)
 
   if config.flutter_path then
     local flutter_path = fn.resolve(config.flutter_path)
-    _paths = { flutter_bin = flutter_path, flutter_sdk = _flutter_sdk_root(flutter_path) }
+    local flutter_bin = config.flutter_bin or flutter_path
+    _paths = { flutter_bin = flutter_bin, flutter_sdk = _flutter_sdk_root(flutter_path) }
     _paths.dart_sdk = _dart_sdk_root(_paths)
     _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk)
     return callback(_paths)


### PR DESCRIPTION
On NixOS using a different `flutter` binary is needed or else commands like `:FlutterRun` won't work as the `flutter` binary that's with `dart-sdk` is different from the "wrapped" `flutter` in `$PATH` this "wrapped" flutter simply runs `flutter` with a lot of required dependencies. I know this similar to [#259](https://github.com/akinsho/flutter-tools.nvim/pull/259) which solves the same problem in a different way. But if this implementation isn't to your liking, I've been also been thinking of an alternative solution where `dart_bin`, `dart_sdk`, `flutter_sdk`, and `flutter_bin` are all possible with the existing system replaced (using `flutter_bin` to find the others if they aren't supplied, similar to how it is now). If I'm correct those options on their own *should* be enough to account for every possible scenario and close all further requests for custom paths.