### PR TITLE
Add lazy.nvim install with integrated setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ using `lazy.nvim`
         'nvim-lua/plenary.nvim',
         'stevearc/dressing.nvim', -- optional for vim.ui.select
     },
-    opts = {}   -- same as calling `require('flutter-tools').setup({})`
+    opts = true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ using `lazy.nvim`
         'nvim-lua/plenary.nvim',
         'stevearc/dressing.nvim', -- optional for vim.ui.select
     },
-    opts = true,
+    config = true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ using `lazy.nvim`
         'nvim-lua/plenary.nvim',
         'stevearc/dressing.nvim', -- optional for vim.ui.select
     },
+    opts = {}   -- same as calling `require('flutter-tools').setup({})`
 }
 ```
 

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -106,6 +106,7 @@ using `lazy.nvim`
             'nvim-lua/plenary.nvim',
             'stevearc/dressing.nvim', -- optional for vim.ui.select
         },
+        opts = {}   -- same as calling `require('flutter-tools').setup({})`
     }
 <
 

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -106,7 +106,6 @@ using `lazy.nvim`
             'nvim-lua/plenary.nvim',
             'stevearc/dressing.nvim', -- optional for vim.ui.select
         },
-        opts = {}   -- same as calling `require('flutter-tools').setup({})`
     }
 <
 


### PR DESCRIPTION
Change documentation to show the lazy.nvim install that includes the flutter-tools setup. Eliminates questions like issue #224.