### PR TITLE
fix(dap): Flutter/Dart project detection improvement

### DIFF
--- a/lua/flutter-tools/dap.lua
+++ b/lua/flutter-tools/dap.lua
@@ -17,8 +17,11 @@ function M.setup(config)
     local root_patterns = { ".git", "pubspec.yaml" }
     local current_dir = vim.fn.expand("%:p:h")
     local root_dir = path.find_root(root_patterns, current_dir) or current_dir
-    local pubspec_path = path.join(root_dir, "pubspec.yaml")
-    local is_flutter_project = pcall(vim.cmd, "silent 1vimgrep! /flutter:\\_s\\+sdk:\\_s\\+flutter\\C/j" .. pubspec_path)
+    local function search_pubspec_for_flutter_sdk()
+      local pubspec_path = path.join(root_dir, "pubspec.yaml")
+      return pcall(vim.cmd, "silent 1vimgrep! /sdk:\\_s\\+flutter\\C/j" .. pubspec_path)
+    end
+    local is_flutter_project = vim.loop.fs_stat(path.join(root_dir, ".metadata")) or search_pubspec_for_flutter_sdk()
 
     if is_flutter_project then
       dap.adapters.dart = {

--- a/lua/flutter-tools/dap.lua
+++ b/lua/flutter-tools/dap.lua
@@ -17,7 +17,8 @@ function M.setup(config)
     local root_patterns = { ".git", "pubspec.yaml" }
     local current_dir = vim.fn.expand("%:p:h")
     local root_dir = path.find_root(root_patterns, current_dir) or current_dir
-    local is_flutter_project = vim.loop.fs_stat(path.join(root_dir, ".metadata"))
+    local pubspec_path = path.join(root_dir, "pubspec.yaml")
+    local is_flutter_project = pcall(vim.cmd, "silent 1vimgrep! /flutter:\\_s\\+sdk:\\_s\\+flutter\\C/j" .. pubspec_path)
 
     if is_flutter_project then
       dap.adapters.dart = {


### PR DESCRIPTION
This PR aims to fix #282 by searching for the flutter sdk dependency from the `pubspec.yaml` file located in the root directory.  This is based on the fact that the `pubspec.yaml` in all flutter projects **requires** the flutter sdk dependency, as stated by [this specification](https://docs.flutter.dev/tools/pubspec). 

This is the simplest way that I can think of to differentiate between flutter or dart project, but any other suggestions are welcome 😀.

EDIT: This is still not a perfect solution as this still doesn't account for any comments that can be provided in the yaml file, but I think with this change and keeping the old behavior should be good enough for most users.