### PR TITLE
feat(dap): add custom commands to nvim-dap

### DIFF
--- a/lua/flutter-tools/dap.lua
+++ b/lua/flutter-tools/dap.lua
@@ -26,6 +26,13 @@ function M.setup(config)
         args = { "debug-adapter" },
       }
       opts.register_configurations(paths)
+      local repl = require("dap.repl")
+      repl.commands = vim.tbl_extend("force", repl.commands, {
+        custom_commands = {
+          [".hot-reload"] = function() dap.session():request("hotReload") end,
+          [".hot-restart"] = function() dap.session():request("hotRestart") end,
+        },
+      })
     else
       dap.adapters.dart = {
         type = "executable",


### PR DESCRIPTION
This simple PR aims to extend the available commands of `nvim-dap` by adding the custom requests `hotReload` and `hotRestart`. 

Being `customRequests` provided by the `flutter debug_adapter` and not part of the DAP standard payload, it makes sense that the flutter plugin extends these functionalities. 

This can also provide a means to use the hot reload functionality even in debug mode, where, as it is now, it is the only reliable way to run nested complex projects (with project configuration). 

- Extends the `DAP`commands repertoire with `hotReload` and `hotRestart` as `.hot-reload` and `.hot-restart`