### PR TITLE
feat: support monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,9 @@ require("flutter-tools").setup {
   },
   flutter_path = "<full/path/if/needed>", -- <-- this takes priority over the lookup
   flutter_lookup_cmd = nil, -- example "dirname $(which flutter)" or "asdf where flutter"
-  root_patterns = { ".git", "pubspec.yaml" }, -- patterns to find the root of your flutter project
+  -- patterns to find the root of your flutter project. In case of monorepo,
+  -- add your monorepo marker here (ex: "melos.yaml")
+  root_patterns = { ".git", "pubspec.yaml" }, 
   fvm = false, -- takes priority over path, uses <workspace>/.fvm/flutter_sdk if enabled
   widget_guides = {
     enabled = false,
@@ -321,6 +323,12 @@ require('flutter-tools').setup_project({
     device = 'chrome',
     flavor = 'WebApp',
     web_port = 4000
+  },
+  {
+    name = 'Monorepo example',
+    device = 'macos',
+    -- make sure to update 'root_patterns' to include your monorepo marker
+    target = 'packages/example/lib/main.dart' 
   },
   {
     name = 'Profile',


### PR DESCRIPTION
In my project, we are using monorepo, so the project structure looks like this:
```
flutter-monorepo
  melos.yaml
  packages
    -- core
    -- module 1
    -- module 2
    -- example
```
With such a structure, in order to be able to run `example` app from any other package, you need to add `melos.yaml` to `root_patterns`. After that, if you try to run the flutter app by specifying target `packages/example/lib/main.dart`, you will get an error "this project is not configured for x (macos/chrome/etc.)" . This happens because `flutter` command is run from the `lsp.get_lsp_root_dir()`, which is `flutter-monorepo`.

I checked how vscode behaves in such situation, and when you specify `packages/example/lib/main.dart` as a target in `launch.json` without explicitly specifying the `cwd` - looks like it will internally check that the flutter package root (`packages/example`) is different from the whole project root (`flutter-monorepo`) and changes the target to be relative to that package.