### PR TITLE
fix: don't attach lsp to buffer with empty path

### DIFF
--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -181,6 +181,8 @@ end
 
 --- Checks if buffer path is valid for attaching LSP
 local function is_valid_path(buffer_path)
+  if buffer_path == "" then return false end
+
   local start_index, _, uri_prefix = buffer_path:find("^(%w+://).*")
   -- Do not attach LSP if file URI prefix is not file.
   -- For example LSP will not be attached for diffview:// or fugitive:// buffers.


### PR DESCRIPTION
For some reason, on one of my projects, LSP tries to attach to a buffer with an empty path. Dart language server recognizes this as `/` root directory and starts to analyze the whole file system and eventually just freezes.
https://github.com/akinsho/flutter-tools.nvim/blob/271eec9edb0f1a2bf30ad449ec3b4eeb2c88af05/lua/flutter-tools/lsp/init.lua#L198
After adding some print statements for debugging, I found out it happens every time the floating window with diagnostic is open. However, there is no such buffer when I check the buffer list with `:ls`, so I'm not sure what exactly causes this. Anyway, check for an empty string is a nice addition to `is_valid_path` function.