### PR TITLE
Fix FlutterWidgetGuides highlight group overwriting custom colors

### DIFF
--- a/lua/flutter-tools/guides.lua
+++ b/lua/flutter-tools/guides.lua
@@ -157,7 +157,9 @@ end
 
 function M.setup()
   local color = utils.get_hl("Normal", "fg")
-  if color and color ~= "" then utils.highlight(hl_group, { foreground = color }) end
+  if color and color ~= "" then
+    utils.highlight(hl_group, { foreground = color, default = true })
+  end
 end
 
 local function is_buf_valid(bufnum)


### PR DESCRIPTION
fix #325

I added a default option to set_hl to prevent overwriting custom colors in FlutterWidgetGuids.