### PR TITLE
fix: remove newline from devtools url notification

### DIFF
--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -85,7 +85,7 @@ end
 
 function M.handle_devtools_available()
   start_browser()
-  ui.notify("Detected devtools url\nExecute FlutterCopyProfilerUrl to copy it")
+  ui.notify("Detected devtools url, execute FlutterCopyProfilerUrl to copy it")
 end
 
 --[[ {


### PR DESCRIPTION
This tiny change makes so we don't have to press a key to dismiss the devtools url notification that shows up when the app launches.

Before:
![before](https://github.com/akinsho/flutter-tools.nvim/assets/58597459/679fc7c5-0a3e-4cb9-92ca-046521bfa4f4)

After:
![after](https://github.com/akinsho/flutter-tools.nvim/assets/58597459/7879187a-88e1-405d-93bf-8c10b34b97be)