### PR TITLE
fix: handle deprecated vim.tbl_islist function

### DIFF
--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -1,6 +1,7 @@
 local lazy = require("flutter-tools.lazy")
 local path = lazy.require("flutter-tools.utils.path") ---@module "flutter-tools.utils.path"
 local ui = lazy.require("flutter-tools.ui") ---@module "flutter-tools.ui"
+local utils = lazy.require("flutter-tools.utils") ---@module "flutter-tools.utils"
 
 ---@class flutter.ProjectConfig
 ---@field name string?
@@ -155,7 +156,7 @@ end
 
 ---@param project flutter.ProjectConfig | flutter.ProjectConfig[]
 function M.setup_project(project)
-  if not vim.tbl_islist(project) then project = { project } end
+  if not utils.islist(project) then project = { project } end
   project_config = project
 end
 

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -141,4 +141,7 @@ function M.emit_event(event, opts)
   api.nvim_exec_autocmds("User", { pattern = event, data = data })
 end
 
+-- TODO: Remove after compatibility with Neovim=0.9 is dropped
+M.islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist
+
 return M


### PR DESCRIPTION
This fixes warning in Neovim nightly build. Related to:
https://github.com/neovim/neovim/issues/24572