### PR TITLE
feat: log_filter for flutter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ require("flutter-tools").setup {
   },
   dev_log = {
     enabled = true,
+    filter = nil, -- optional callback to filter the log
+    -- takes a log_line as string argument; returns a boolean or nil;
+    -- the log_line is only added to the output if the function returns true
     notify_errors = false, -- if there is an error whilst running then notify the user
     open_cmd = "tabedit", -- command to use to open the log buffer
   },

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -128,6 +128,7 @@ local config = {
     __index = function(_, k) return k == "open_cmd" and get_split_cmd(0.3, 40) or nil end,
   }),
   dev_log = setmetatable({
+    filter = nil,
     enabled = true,
     notify_errors = false,
   }, {

--- a/lua/flutter-tools/log.lua
+++ b/lua/flutter-tools/log.lua
@@ -87,6 +87,7 @@ end
 function M.log(data, opts)
   if opts.enabled then
     if not exists() then create(opts) end
+    if opts.filter and not opts.filter(data) then return end
     append(M.buf, { data })
     autoscroll(M.buf, M.win)
   end


### PR DESCRIPTION
I encountered spammy logs in flutter, that looked something like this:
```
[…]
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
E/GPUAUX  ( 4115): [AUX]GuiExtAuxCheckAuxPath:666: Null anb
I/gralloc4( 4115): @set_metadata: update dataspace from GM (0x00000000 -> 0x08010000)
[…]
```

When I execute `flutter run` via the CLI, I have a grep command that removes these lines for me. Sadly I did not find an easy way to use my wrapper function (with fvm) inside flutter-tools, so I decided to implement the feature directly in here.
It is the cleanest solution afterall, I suppose.

I also included an example of what the filter could look like. This is the one I use - because I only care about flutter logs on my dev phone.