### PR TITLE
feat: Add option to set closing tag virtual text priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ require("flutter-tools").setup {
   closing_tags = {
     highlight = "ErrorMsg", -- highlight for the closing tag
     prefix = ">", -- character to use for close tag e.g. > Widget
+    priority = 10, -- priority of virtual text in current line
+    -- consider to configure this when there is a possibility of multiple virtual text items in one line
+    -- see `priority` option in |:help nvim_buf_set_extmark| for more info
     enabled = true -- set to false to disable
   },
   dev_log = {

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -272,6 +272,9 @@ both are set.
       closing_tags = {
         highlight = "ErrorMsg", -- highlight for the closing tag
         prefix = ">", -- character to use for close tag e.g. > Widget
+        priority = 10, -- priority of virtual text in current line
+        -- consider to configure this when there is a possibility of multiple virtual text items in one line
+        -- see `priority` option in |:help nvim_buf_set_extmark| for more info
         enabled = true -- set to false to disable
       },
       dev_log = {

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -109,6 +109,7 @@ local config = {
   closing_tags = {
     highlight = "Comment",
     prefix = "// ",
+    priority = 0,
     enabled = true,
   },
   lsp = {

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -109,7 +109,7 @@ local config = {
   closing_tags = {
     highlight = "Comment",
     prefix = "// ",
-    priority = 0,
+    priority = 10,
     enabled = true,
   },
   lsp = {

--- a/lua/flutter-tools/labels.lua
+++ b/lua/flutter-tools/labels.lua
@@ -12,7 +12,7 @@ local function render_labels(labels, opts)
   opts = opts or {}
   local highlight = opts and opts.highlight or "Comment"
   local prefix = opts and opts.prefix or "// "
-  local priority = opts and opts.priority or 0
+  local priority = opts and opts.priority or 10
 
   for _, item in ipairs(labels) do
     local line = tonumber(item.range["end"].line)

--- a/lua/flutter-tools/labels.lua
+++ b/lua/flutter-tools/labels.lua
@@ -12,6 +12,7 @@ local function render_labels(labels, opts)
   opts = opts or {}
   local highlight = opts and opts.highlight or "Comment"
   local prefix = opts and opts.prefix or "// "
+  local priority = opts and opts.priority or 0
 
   for _, item in ipairs(labels) do
     local line = tonumber(item.range["end"].line)
@@ -23,6 +24,7 @@ local function render_labels(labels, opts)
         } },
         virt_text_pos = "eol",
         hl_mode = "combine",
+        priority = priority,
       })
     end
   end


### PR DESCRIPTION
This PR adds an option to set the priority for the closing tags virtual text.

This would help keep the order of virtual text items configurable, in cases when there are multiple virtual text items, eg.: git blame text from the `gitsigns` plugin or with LSP diagnostics text.

Example:

Current behavior (not preferable, especially in cases when commit messages are longer):
![Screenshot_20240817_235218](https://github.com/user-attachments/assets/9611c93a-7022-4def-8cf4-2e21da9b80e0)

When the priority is set (to 0, in this case) (preferable, as the tag is always kept next to the actual code):
![Screenshot_20240817_235109](https://github.com/user-attachments/assets/3c9a108c-3523-4dfb-ba43-934868d4605f)

I've kept the default priority to be `0`, as I think logically one would want this text to be closest to the code. Open to discuss if there are any other thoughts on this.

Do let me know your thoughts on this. If this looks like a good change to have, I can add this in the docs (vimdoc and README) as well.
Thanks!