### PR TITLE
refact(debugging): remove `run_via_dap` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ require("flutter-tools").setup {
   },
   debugger = { -- integrate with nvim dap + install dart code debugger
     enabled = false,
-    run_via_dap = false, -- use dap instead of a plenary job to run flutter apps
     -- if empty dap will not stop on any exceptions, otherwise it will stop on those specified
     -- see |:help dap.set_exception_breakpoints()| for more info
     exception_breakpoints = {}
@@ -435,9 +434,6 @@ If `dap` is this plugin will use `flutter` or `dart` native debugger to debug yo
 To use the debugger you need to run `:lua require('dap').continue()<CR>`. This will start your app. You should then be able
 to use `dap` commands to begin to debug it. For more information on how to use `nvim-dap` please read the project's README
 or see `:h dap`. Note that running the app this way will prevent commands such as `:FlutterRestart`, `:FlutterReload` from working.
-
-Alternatively, if you prefer always running your app via dap, you can set `debugger.run_via_dap = true` in your config.
-This way you benefit from the debugging abilities of DAP, AND you can still use `:FlutterRestart`, `:FlutterReload`, etc.
 
 You can use the `debugger.register_configurations` to register custom runner configuration (for example for different targets or flavor).
 If your flutter repo contains launch configurations in `.vscode/launch.json` you can use them via this config :

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -252,7 +252,6 @@ both are set.
       },
       debugger = { -- integrate with nvim dap + install dart code debugger
         enabled = false,
-        run_via_dap = false, -- use dap instead of a plenary job to run flutter apps
         -- if empty dap will not stop on any exceptions, otherwise it will stop on those specified
         -- see |:help dap.set_exception_breakpoints()| for more info
         exception_breakpoints = {}
@@ -495,11 +494,6 @@ will start your app. You should then be able to use `dap` commands to begin to
 debug it. For more information on how to use `nvim-dap` please read the
 project’s README or see |dap|. Note that running the app this way will
 prevent commands such as `:FlutterRestart`, `:FlutterReload` from working.
-
-Alternatively, if you prefer always running your app via dap, you can set
-`debugger.run_via_dap = true` in your config. This way you benefit from the
-debugging abilities of DAP, AND you can still use `:FlutterRestart`,
-`:FlutterReload`, etc.
 
 You can use the `debugger.register_configurations` to register custom runner
 configuration (for example for different targets or flavor). If your flutter

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -28,13 +28,10 @@ local current_device = nil
 local runner = nil
 
 local function use_debugger_runner()
-  local dap_ok, dap = pcall(require, "dap")
-  if not config.debugger.run_via_dap then return false end
+  if not config.debugger.enabled then return false end
+  local dap_ok, _ = pcall(require, "dap")
   if dap_ok then return true end
-  ui.notify(
-    utils.join({ "debugger runner was request but nvim-dap is not installed!", dap }),
-    ui.ERROR
-  )
+  ui.notify("debugger runner was request but nvim-dap is not installed!", ui.ERROR)
   return false
 end
 
@@ -421,7 +418,6 @@ end
 
 ---@param args string[]
 ---@param project_conf flutter.ProjectConfig?
----@return string[]
 local function set_args_from_project_config(args, project_conf)
   local flavor = project_conf and project_conf.flavor
   local device = project_conf and project_conf.device

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -81,7 +81,6 @@ local config = {
   },
   debugger = {
     enabled = false,
-    run_via_dap = false,
     exception_breakpoints = nil,
     register_configurations = function(paths)
       require("dap").configurations.dart = {

--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -79,7 +79,6 @@ function DebuggerRunner:run(paths, args, cwd, on_run_data, on_run_exit)
     end
   end
 
-  local launch_config
   if launch_configuration_count == 0 then
     ui.notify("No launch configuration for DAP found", ui.ERROR)
     return


### PR DESCRIPTION
As `dap` is the default protocol for Flutter, this option is not needed anymore. To toggle debugging, the `config.debugger.enabled` option should be used.