### PR TITLE
feat(dap): add option `evaluate_to_string_in_debug_views`

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ require("flutter-tools").setup {
     -- if empty dap will not stop on any exceptions, otherwise it will stop on those specified
     -- see |:help dap.set_exception_breakpoints()| for more info
     exception_breakpoints = {}
+    -- Whether to call toString() on objects in debug views like hovers and the
+    -- variables list.
+    -- Invoking toString() has a performance cost and may introduce side-effects,
+    -- although users may expected this functionality. null is treated like false.
+    evaluate_to_string_in_debug_views = true,
     register_configurations = function(paths)
       require("dap").configurations.dart = {
         <put here config that you would find in .vscode/launch.json>

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -83,6 +83,7 @@ local config = {
     enabled = false,
     run_via_dap = false,
     exception_breakpoints = nil,
+    evaluate_to_string_in_debug_views = true,
     register_configurations = function(paths)
       require("dap").configurations.dart = {
         {

--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -97,6 +97,9 @@ function DebuggerRunner:run(paths, args, cwd, on_run_data, on_run_exit)
         launch_config.args = vim.list_extend(launch_config.args or {}, args or {})
         launch_config.dartSdkPath = paths.dart_sdk
         launch_config.flutterSdkPath = paths.flutter_sdk
+        if config.debugger.evaluate_to_string_in_debug_views then
+          launch_config.evaluateToStringInDebugViews = true
+        end
         dap.run(launch_config)
       end
     )


### PR DESCRIPTION
Without option:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/c7f690ab-d4dc-42a1-9546-d96c0973979d">

With option:
<img width="445" alt="image" src="https://github.com/user-attachments/assets/adf74399-7f9f-47b4-b552-4857d06138bb">

This option will be enabled by default (DartCode has it enabled too.)

Reference https://github.com/dart-lang/sdk/blob/a70adce28e53ff8bb3445fe96f3f1be951d8a417/pkg/dds/lib/src/dap/adapters/dart.dart#L203
