### PR TITLE
fix: adapt to nvim depractions

### DIFF
--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -149,6 +149,6 @@ end
 -- TODO: Remove after compatibility with Neovim=0.9 is dropped
 M.islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist
 local flatten = function(t) return vim.iter(t):flatten():totable() end
-M.flatten = vim.fn.has("nvim-0.10") == 1 and flatten or vim.tbl_flatten
+M.flatten = vim.fn.has("nvim-0.11") == 1 and flatten or vim.tbl_flatten
 
 return M


### PR DESCRIPTION
Possibly fixes #378 . Looks like `vim.iter(...):flatten():totable()` is NOT a exact drop-in replacement of `vim.tbl_flatten`. It does not handle nil values. Fixes were made in https://github.com/neovim/neovim/pull/28781 to address the issue.